### PR TITLE
Bugfix/#65 2차 자체 QA 버그 수정

### DIFF
--- a/app/src/main/java/com/sseotdabwa/buyornot/navigation/BuyOrNotNavHost.kt
+++ b/app/src/main/java/com/sseotdabwa/buyornot/navigation/BuyOrNotNavHost.kt
@@ -12,6 +12,7 @@ import com.sseotdabwa.buyornot.core.ui.snackbar.LocalSnackbarState
 import com.sseotdabwa.buyornot.core.ui.webview.navigateToPrivacyPolicy
 import com.sseotdabwa.buyornot.core.ui.webview.navigateToTerms
 import com.sseotdabwa.buyornot.core.ui.webview.webViewScreen
+import com.sseotdabwa.buyornot.feature.auth.navigation.AUTH_ROUTE
 import com.sseotdabwa.buyornot.feature.auth.navigation.SPLASH_ROUTE
 import com.sseotdabwa.buyornot.feature.auth.navigation.authScreen
 import com.sseotdabwa.buyornot.feature.auth.navigation.navigateForceToLogin
@@ -79,7 +80,7 @@ fun BuyOrNotNavHost(
                 navController.navigateToHome(
                     navOptions =
                         androidx.navigation.navOptions {
-                            popUpTo(SPLASH_ROUTE) { inclusive = true }
+                            popUpTo(AUTH_ROUTE) { inclusive = true }
                             launchSingleTop = true
                         },
                 )

--- a/core/designsystem/src/main/java/com/sseotdabwa/buyornot/core/designsystem/components/SnackBar.kt
+++ b/core/designsystem/src/main/java/com/sseotdabwa/buyornot/core/designsystem/components/SnackBar.kt
@@ -1,8 +1,6 @@
 package com.sseotdabwa.buyornot.core.designsystem.components
 
 import androidx.compose.animation.AnimatedContent
-import androidx.compose.animation.EnterTransition
-import androidx.compose.animation.ExitTransition
 import androidx.compose.animation.SizeTransform
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
@@ -17,6 +15,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -47,11 +46,15 @@ import com.sseotdabwa.buyornot.core.designsystem.icon.IconResource
 import com.sseotdabwa.buyornot.core.designsystem.theme.BuyOrNotTheme
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withTimeout
 
 private val SnackbarVerticalMargin = 10.dp
 private val SnackbarHorizontalMargin = 20.dp
 private val SnackbarMaxWidth = 800.dp
+
+private val snackbarMutex = Mutex()
 
 enum class SnackBarIconTint {
     Success,
@@ -119,26 +122,15 @@ fun BuyOrNotSnackBar(
 fun BuyOrNotSnackBarHost(hostState: SnackbarHostState) {
     AnimatedContent(
         targetState = hostState.currentSnackbarData,
-        modifier = Modifier.fillMaxWidth(),
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .navigationBarsPadding(),
         contentAlignment = Alignment.BottomCenter,
         transitionSpec = {
-            val slideUp = slideInVertically(tween(400)) { it } + fadeIn(tween(400))
-            val slideDown = slideOutVertically(tween(400)) { it } + fadeOut(tween(400))
-
-            when {
-                targetState != null && initialState != null -> {
-                    // 새 메시지가 이전 메시지를 아래로 밀어내며 올라옴
-                    slideUp.togetherWith(slideDown).using(SizeTransform(clip = false))
-                }
-                targetState != null -> {
-                    // 최초 등장: 아래에서 올라옴
-                    slideUp.togetherWith(ExitTransition.None).using(SizeTransform(clip = false))
-                }
-                else -> {
-                    // Dismiss: 아래로 부드럽게 사라짐 (SizeTransform 없이 자연스럽게)
-                    EnterTransition.None.togetherWith(slideDown)
-                }
-            }
+            (slideInVertically { it } + fadeIn(tween(400)))
+                .togetherWith(slideOutVertically(animationSpec = tween(400)) { it } + fadeOut(tween(400)))
+                .using(SizeTransform(clip = false))
         },
         label = "BuyOrNotSnackBarAnimation",
     ) { data ->
@@ -181,27 +173,25 @@ suspend fun showBuyOrNotSnackBar(
     iconResource: IconResource? = null,
     iconTint: SnackBarIconTint = SnackBarIconTint.Success,
     duration: SnackbarDuration = SnackbarDuration.Short,
-): SnackbarResult {
-    // 현재 표시 중인 스낵바를 즉시 dismiss하여 새 메시지가 바로 교체되도록 함
-    snackbarHostState.currentSnackbarData?.dismiss()
-
-    return try {
-        withTimeout(duration.toMillis()) {
-            snackbarHostState.showSnackbar(
-                BuyOrNotSnackBarVisuals(
-                    message = message,
-                    iconResource = iconResource,
-                    iconTint = iconTint,
-                    duration = SnackbarDuration.Indefinite, // 직접 타이머 제어
-                ),
-            )
+): SnackbarResult =
+    snackbarMutex.withLock {
+        try {
+            withTimeout(duration.toMillis()) {
+                snackbarHostState.showSnackbar(
+                    BuyOrNotSnackBarVisuals(
+                        message = message,
+                        iconResource = iconResource,
+                        iconTint = iconTint,
+                        duration = SnackbarDuration.Indefinite, // 직접 타이머 제어
+                    ),
+                )
+            }
+        } catch (_: TimeoutCancellationException) {
+            SnackbarResult.Dismissed
+        } finally {
+            snackbarHostState.currentSnackbarData?.dismiss()
         }
-    } catch (_: TimeoutCancellationException) {
-        SnackbarResult.Dismissed
-    } finally {
-        snackbarHostState.currentSnackbarData?.dismiss()
     }
-}
 
 private fun SnackbarDuration.toMillis(): Long =
     when (this) {

--- a/core/designsystem/src/main/java/com/sseotdabwa/buyornot/core/designsystem/components/SnackBar.kt
+++ b/core/designsystem/src/main/java/com/sseotdabwa/buyornot/core/designsystem/components/SnackBar.kt
@@ -1,6 +1,8 @@
 package com.sseotdabwa.buyornot.core.designsystem.components
 
 import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
 import androidx.compose.animation.SizeTransform
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
@@ -45,15 +47,11 @@ import com.sseotdabwa.buyornot.core.designsystem.icon.IconResource
 import com.sseotdabwa.buyornot.core.designsystem.theme.BuyOrNotTheme
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withTimeout
 
 private val SnackbarVerticalMargin = 10.dp
 private val SnackbarHorizontalMargin = 20.dp
 private val SnackbarMaxWidth = 800.dp
-
-private val snackbarMutex = Mutex()
 
 enum class SnackBarIconTint {
     Success,
@@ -124,9 +122,23 @@ fun BuyOrNotSnackBarHost(hostState: SnackbarHostState) {
         modifier = Modifier.fillMaxWidth(),
         contentAlignment = Alignment.BottomCenter,
         transitionSpec = {
-            (slideInVertically { it } + fadeIn(tween(400)))
-                .togetherWith(slideOutVertically(animationSpec = tween(400)) { it } + fadeOut(tween(400)))
-                .using(SizeTransform(clip = false))
+            val slideUp = slideInVertically(tween(400)) { it } + fadeIn(tween(400))
+            val slideDown = slideOutVertically(tween(400)) { it } + fadeOut(tween(400))
+
+            when {
+                targetState != null && initialState != null -> {
+                    // 새 메시지가 이전 메시지를 아래로 밀어내며 올라옴
+                    slideUp.togetherWith(slideDown).using(SizeTransform(clip = false))
+                }
+                targetState != null -> {
+                    // 최초 등장: 아래에서 올라옴
+                    slideUp.togetherWith(ExitTransition.None).using(SizeTransform(clip = false))
+                }
+                else -> {
+                    // Dismiss: 아래로 부드럽게 사라짐 (SizeTransform 없이 자연스럽게)
+                    EnterTransition.None.togetherWith(slideDown)
+                }
+            }
         },
         label = "BuyOrNotSnackBarAnimation",
     ) { data ->
@@ -169,25 +181,27 @@ suspend fun showBuyOrNotSnackBar(
     iconResource: IconResource? = null,
     iconTint: SnackBarIconTint = SnackBarIconTint.Success,
     duration: SnackbarDuration = SnackbarDuration.Short,
-): SnackbarResult =
-    snackbarMutex.withLock {
-        try {
-            withTimeout(duration.toMillis()) {
-                snackbarHostState.showSnackbar(
-                    BuyOrNotSnackBarVisuals(
-                        message = message,
-                        iconResource = iconResource,
-                        iconTint = iconTint,
-                        duration = SnackbarDuration.Indefinite, // 직접 타이머 제어
-                    ),
-                )
-            }
-        } catch (_: TimeoutCancellationException) {
-            SnackbarResult.Dismissed
-        } finally {
-            snackbarHostState.currentSnackbarData?.dismiss()
+): SnackbarResult {
+    // 현재 표시 중인 스낵바를 즉시 dismiss하여 새 메시지가 바로 교체되도록 함
+    snackbarHostState.currentSnackbarData?.dismiss()
+
+    return try {
+        withTimeout(duration.toMillis()) {
+            snackbarHostState.showSnackbar(
+                BuyOrNotSnackBarVisuals(
+                    message = message,
+                    iconResource = iconResource,
+                    iconTint = iconTint,
+                    duration = SnackbarDuration.Indefinite, // 직접 타이머 제어
+                ),
+            )
         }
+    } catch (_: TimeoutCancellationException) {
+        SnackbarResult.Dismissed
+    } finally {
+        snackbarHostState.currentSnackbarData?.dismiss()
     }
+}
 
 private fun SnackbarDuration.toMillis(): Long =
     when (this) {

--- a/feature/home/src/main/java/com/sseotdabwa/buyornot/feature/home/ui/HomeContract.kt
+++ b/feature/home/src/main/java/com/sseotdabwa/buyornot/feature/home/ui/HomeContract.kt
@@ -66,6 +66,7 @@ data class HomeUiState(
     val voterProfileImageUrl: String = "",
     val feeds: List<FeedItem> = emptyList(),
     val isLoading: Boolean = true,
+    val isRefreshing: Boolean = false,
     val isNextPageLoading: Boolean = false,
     val hasNextPage: Boolean = false,
     val nextCursor: Long? = null,
@@ -102,6 +103,8 @@ sealed interface HomeIntent {
     data object LoadFeeds : HomeIntent
 
     data object LoadNextPage : HomeIntent
+
+    data object Refresh : HomeIntent
 }
 
 /**

--- a/feature/home/src/main/java/com/sseotdabwa/buyornot/feature/home/ui/HomeScreen.kt
+++ b/feature/home/src/main/java/com/sseotdabwa/buyornot/feature/home/ui/HomeScreen.kt
@@ -14,7 +14,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
@@ -31,17 +30,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
-import androidx.compose.ui.input.nestedscroll.NestedScrollSource
-import androidx.compose.ui.input.nestedscroll.nestedScroll
-import androidx.compose.ui.layout.SubcomposeLayout
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.Constraints
-import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -65,7 +55,6 @@ import com.sseotdabwa.buyornot.core.designsystem.theme.BuyOrNotTheme
 import com.sseotdabwa.buyornot.domain.model.UserType
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filter
-import kotlin.math.roundToInt
 
 /**
  * 홈 화면 루트 컴포저블
@@ -142,54 +131,7 @@ fun HomeScreen(
     // 화면 전용 일시적 상태 (ViewModel에서 관리하지 않음)
     var isFabExpanded by remember { mutableStateOf(false) }
 
-    val density = LocalDensity.current
-    var topBarHeightPx by remember { mutableStateOf(0f) }
-    var tabHeightPx by remember { mutableStateOf(0f) }
-
-    val totalHeaderHeight = with(density) { (topBarHeightPx + tabHeightPx).toDp() }
-
-    // TopBar 오프셋 상태 (0 = 보임, -topBarHeightPx = 숨김)
-    var topBarOffsetHeightPx by remember { mutableStateOf(0f) }
-
-    // 스크롤 가능한 콘텐츠가 있는지 확인 (피드가 있을 때만 스크롤 활성화)
-    val hasScrollableContent = uiState.feeds.isNotEmpty()
-
-    val nestedScrollConnection =
-        remember(topBarHeightPx, hasScrollableContent) {
-            object : NestedScrollConnection {
-                override fun onPreScroll(
-                    available: Offset,
-                    source: NestedScrollSource,
-                ): Offset {
-                    // 스크롤 가능한 콘텐츠가 없으면 스크롤 연결 비활성화
-                    if (!hasScrollableContent) {
-                        return Offset.Zero
-                    }
-
-                    val delta = available.y
-                    val newOffset = topBarOffsetHeightPx + delta
-                    topBarOffsetHeightPx = newOffset.coerceIn(-topBarHeightPx, 0f)
-                    return Offset.Zero
-                }
-            }
-        }
-
-    // 콘텐츠 상태가 변경되면 오프셋 리셋
-    LaunchedEffect(topBarHeightPx, hasScrollableContent) {
-        topBarOffsetHeightPx =
-            if (!hasScrollableContent) {
-                0f
-            } else {
-                topBarOffsetHeightPx.coerceIn(-topBarHeightPx, 0f)
-            }
-    }
-
-    Box(
-        modifier =
-            Modifier
-                .fillMaxSize()
-                .nestedScroll(nestedScrollConnection),
-    ) {
+    Box(modifier = Modifier.fillMaxSize()) {
         Scaffold(
             snackbarHost = { BuyOrNotSnackBarHost(snackbarHostState) },
             floatingActionButton = {
@@ -204,7 +146,10 @@ fun HomeScreen(
             HomeFeedList(
                 uiState = uiState,
                 onIntent = onIntent,
-                headerPadding = totalHeaderHeight + innerPadding.calculateTopPadding(),
+                contentPadding = innerPadding,
+                onLoginClick = onLoginClick,
+                onNotificationClick = onNotificationClick,
+                onProfileClick = onProfileClick,
                 onUploadClick = onUploadClick,
             )
 
@@ -213,97 +158,23 @@ fun HomeScreen(
                 onDismiss = { isFabExpanded = false },
             )
         }
-
-        HomeHeader(
-            uiState = uiState,
-            onLoginClick = onLoginClick,
-            onNotificationClick = onNotificationClick,
-            onProfileClick = onProfileClick,
-            onTabSelected = { onIntent(HomeIntent.OnTabSelected(it)) },
-            currentTopBarHeightPx = topBarHeightPx,
-            currentTabHeightPx = tabHeightPx,
-            onHeightsMeasured = { topBar, tab ->
-                topBarHeightPx = topBar
-                tabHeightPx = tab
-            },
-            modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .offset { IntOffset(x = 0, y = topBarOffsetHeightPx.roundToInt()) }
-                    .background(BuyOrNotTheme.colors.gray0),
-        )
     }
 }
 
-private enum class HomeHeaderSlot {
-    TopBar,
-    Tab,
-}
-
 @Composable
-private fun HomeHeader(
-    uiState: HomeUiState,
+private fun HomeTopBarSection(
+    userType: UserType,
     onLoginClick: () -> Unit,
     onNotificationClick: () -> Unit,
     onProfileClick: () -> Unit,
-    onTabSelected: (HomeTab) -> Unit,
-    currentTopBarHeightPx: Float,
-    currentTabHeightPx: Float,
-    onHeightsMeasured: (Float, Float) -> Unit,
-    modifier: Modifier = Modifier,
 ) {
-    SubcomposeLayout(modifier = modifier) { constraints ->
-        val width = constraints.maxWidth
-        val childConstraints =
-            if (width == Constraints.Infinity) {
-                constraints
-            } else {
-                Constraints.fixedWidth(width)
-            }
-
-        val topBarPlaceable =
-            subcompose(HomeHeaderSlot.TopBar) {
-                when (uiState.userType) {
-                    UserType.GUEST -> {
-                        GuestTopBar(
-                            onLoginClick = onLoginClick,
-                        )
-                    }
-                    UserType.SOCIAL -> {
-                        HomeTopBar(
-                            onNotificationClick = onNotificationClick,
-                            onProfileClick = onProfileClick,
-                        )
-                    }
-                }
-            }.first().measure(childConstraints)
-
-        val tabPlaceable =
-            subcompose(HomeHeaderSlot.Tab) {
-                HomeTabSection(
-                    userType = uiState.userType,
-                    selectedTab = uiState.selectedTab,
-                    onTabSelected = onTabSelected,
-                )
-            }.first().measure(childConstraints)
-
-        val newTopBarHeight = topBarPlaceable.height.toFloat()
-        val newTabHeight = tabPlaceable.height.toFloat()
-
-        if (newTopBarHeight != currentTopBarHeightPx || newTabHeight != currentTabHeightPx) {
-            onHeightsMeasured(newTopBarHeight, newTabHeight)
-        }
-
-        val layoutWidth =
-            if (width == Constraints.Infinity) {
-                topBarPlaceable.width.coerceAtLeast(tabPlaceable.width)
-            } else {
-                width
-            }
-
-        layout(width = layoutWidth, height = topBarPlaceable.height + tabPlaceable.height) {
-            topBarPlaceable.place(0, 0)
-            tabPlaceable.place(0, topBarPlaceable.height)
+    when (userType) {
+        UserType.GUEST -> GuestTopBar(onLoginClick = onLoginClick)
+        UserType.SOCIAL -> {
+            HomeTopBar(
+                onNotificationClick = onNotificationClick,
+                onProfileClick = onProfileClick,
+            )
         }
     }
 }
@@ -411,7 +282,10 @@ private fun FabDimOverlay(
 private fun HomeFeedList(
     uiState: HomeUiState,
     onIntent: (HomeIntent) -> Unit,
-    headerPadding: Dp,
+    contentPadding: PaddingValues,
+    onLoginClick: () -> Unit,
+    onNotificationClick: () -> Unit,
+    onProfileClick: () -> Unit,
     onUploadClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -440,9 +314,27 @@ private fun HomeFeedList(
     LazyColumn(
         state = listState,
         modifier = modifier.fillMaxSize(),
-        contentPadding = PaddingValues(top = headerPadding),
+        contentPadding = contentPadding,
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
+        item {
+            HomeTopBarSection(
+                userType = uiState.userType,
+                onLoginClick = onLoginClick,
+                onNotificationClick = onNotificationClick,
+                onProfileClick = onProfileClick,
+            )
+        }
+
+        stickyHeader {
+            HomeTabSection(
+                userType = uiState.userType,
+                selectedTab = uiState.selectedTab,
+                onTabSelected = { onIntent(HomeIntent.OnTabSelected(it)) },
+                modifier = Modifier.background(BuyOrNotTheme.colors.gray0),
+            )
+        }
+
         // 공통 필터 칩 영역
         item {
             Spacer(modifier = Modifier.height(16.dp))

--- a/feature/home/src/main/java/com/sseotdabwa/buyornot/feature/home/ui/HomeScreen.kt
+++ b/feature/home/src/main/java/com/sseotdabwa/buyornot/feature/home/ui/HomeScreen.kt
@@ -403,7 +403,16 @@ private fun HomeFeedList(
                     }
                 }
 
-                // 2. 로딩이 끝난 단계 (isLoading == false)
+                // 2. 로딩 중인 단계 (로딩이 끝나기 전까지는 Result를 판단하지 않음)
+                uiState.isLoading -> {
+                    item {
+                        Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                            CircularProgressIndicator(color = BuyOrNotTheme.colors.gray900)
+                        }
+                    }
+                }
+
+                // 3. 로딩이 끝난 단계 (isLoading == false)
                 uiState.hasError -> {
                     // 통신 실패로 로딩이 끝난 경우
                     item {

--- a/feature/home/src/main/java/com/sseotdabwa/buyornot/feature/home/ui/HomeScreen.kt
+++ b/feature/home/src/main/java/com/sseotdabwa/buyornot/feature/home/ui/HomeScreen.kt
@@ -403,16 +403,7 @@ private fun HomeFeedList(
                     }
                 }
 
-                // 2. 로딩 중인 단계 (로딩이 끝나기 전까지는 Result를 판단하지 않음)
-                uiState.isLoading -> {
-                    item {
-                        Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                            CircularProgressIndicator(color = BuyOrNotTheme.colors.gray900)
-                        }
-                    }
-                }
-
-                // 3. 로딩이 끝난 단계 (isLoading == false)
+                // 2. 로딩이 끝난 단계 (isLoading == false)
                 uiState.hasError -> {
                     // 통신 실패로 로딩이 끝난 경우
                     item {

--- a/feature/home/src/main/java/com/sseotdabwa/buyornot/feature/home/ui/HomeScreen.kt
+++ b/feature/home/src/main/java/com/sseotdabwa/buyornot/feature/home/ui/HomeScreen.kt
@@ -19,8 +19,10 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -278,6 +280,7 @@ private fun FabDimOverlay(
 /**
  * 홈 화면의 메인 피드 리스트 컴포넌트
  */
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun HomeFeedList(
     uiState: HomeUiState,
@@ -311,117 +314,123 @@ private fun HomeFeedList(
             }
     }
 
-    LazyColumn(
-        state = listState,
+    PullToRefreshBox(
+        isRefreshing = uiState.isRefreshing,
+        onRefresh = { onIntent(HomeIntent.Refresh) },
         modifier = modifier.fillMaxSize(),
-        contentPadding = contentPadding,
-        horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        item {
-            HomeTopBarSection(
-                userType = uiState.userType,
-                onLoginClick = onLoginClick,
-                onNotificationClick = onNotificationClick,
-                onProfileClick = onProfileClick,
-            )
-        }
-
-        stickyHeader {
-            HomeTabSection(
-                userType = uiState.userType,
-                selectedTab = uiState.selectedTab,
-                onTabSelected = { onIntent(HomeIntent.OnTabSelected(it)) },
-                modifier = Modifier.background(BuyOrNotTheme.colors.gray0),
-            )
-        }
-
-        // 공통 필터 칩 영역
-        item {
-            Spacer(modifier = Modifier.height(16.dp))
-            FilterChipRow(
-                selectedFilter = uiState.selectedFilter,
-                onFilterSelected = { onIntent(HomeIntent.OnFilterSelected(it)) },
-            )
-            // 배너 (투표 피드 탭이고 isBannerVisible이 true일 때만 표시)
-            if (filteredFeeds.isNotEmpty() && uiState.isBannerVisible && uiState.selectedTab == HomeTab.FEED) {
-                Spacer(modifier = Modifier.height(16.dp))
-
-                HomeBanner(
-                    modifier = Modifier.padding(horizontal = 20.dp),
-                    onDismiss = { onIntent(HomeIntent.OnBannerDismissed) },
-                    onClick = onUploadClick,
-                )
-
-                Spacer(modifier = Modifier.height(16.dp))
-
-                BuyOrNotDivider(
-                    size = BuyOrNotDividerSize.Small,
-                    modifier = Modifier.padding(horizontal = 20.dp),
+        LazyColumn(
+            state = listState,
+            modifier = Modifier.fillMaxSize(),
+            contentPadding = contentPadding,
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            item {
+                HomeTopBarSection(
+                    userType = uiState.userType,
+                    onLoginClick = onLoginClick,
+                    onNotificationClick = onNotificationClick,
+                    onProfileClick = onProfileClick,
                 )
             }
-        }
 
-        when {
-            // 1. 데이터가 있으면 로딩 여부와 상관없이 최우선 노출
-            filteredFeeds.isNotEmpty() -> {
-                // 피드 리스트 및 배너 노출 로직 (기존과 동일)
-                items(filteredFeeds.size, key = { index -> filteredFeeds[index].id }) { index ->
-                    FeedItemCard(
-                        feed = filteredFeeds[index],
-                        voterProfileImageUrl = uiState.voterProfileImageUrl,
-                        modifier = Modifier.padding(20.dp).animateItem(),
-                        onVote = { id, opt -> onIntent(HomeIntent.OnVoteClicked(id, opt)) },
-                        onDelete = { id -> onIntent(HomeIntent.OnDeleteClicked(id)) },
-                        onReport = { id -> onIntent(HomeIntent.OnReportClicked(id)) },
+            stickyHeader {
+                HomeTabSection(
+                    userType = uiState.userType,
+                    selectedTab = uiState.selectedTab,
+                    onTabSelected = { onIntent(HomeIntent.OnTabSelected(it)) },
+                    modifier = Modifier.background(BuyOrNotTheme.colors.gray0),
+                )
+            }
+
+            // 공통 필터 칩 영역
+            item {
+                Spacer(modifier = Modifier.height(16.dp))
+                FilterChipRow(
+                    selectedFilter = uiState.selectedFilter,
+                    onFilterSelected = { onIntent(HomeIntent.OnFilterSelected(it)) },
+                )
+                // 배너 (투표 피드 탭이고 isBannerVisible이 true일 때만 표시)
+                if (filteredFeeds.isNotEmpty() && uiState.isBannerVisible && uiState.selectedTab == HomeTab.FEED) {
+                    Spacer(modifier = Modifier.height(16.dp))
+
+                    HomeBanner(
+                        modifier = Modifier.padding(horizontal = 20.dp),
+                        onDismiss = { onIntent(HomeIntent.OnBannerDismissed) },
+                        onClick = onUploadClick,
+                    )
+
+                    Spacer(modifier = Modifier.height(16.dp))
+
+                    BuyOrNotDivider(
+                        size = BuyOrNotDividerSize.Small,
+                        modifier = Modifier.padding(horizontal = 20.dp),
                     )
                 }
+            }
 
-                // 다음 페이지 로딩 중일 때 표시
-                if (uiState.isNextPageLoading) {
-                    item {
-                        Box(
-                            modifier =
-                                Modifier
-                                    .fillMaxWidth()
-                                    .padding(vertical = 16.dp),
-                            contentAlignment = Alignment.Center,
-                        ) {
-                            CircularProgressIndicator(
-                                color = BuyOrNotTheme.colors.gray900,
-                                strokeWidth = 2.dp,
-                            )
+            when {
+                // 1. 데이터가 있으면 로딩 여부와 상관없이 최우선 노출
+                filteredFeeds.isNotEmpty() -> {
+                    // 피드 리스트 및 배너 노출 로직 (기존과 동일)
+                    items(filteredFeeds.size, key = { index -> filteredFeeds[index].id }) { index ->
+                        FeedItemCard(
+                            feed = filteredFeeds[index],
+                            voterProfileImageUrl = uiState.voterProfileImageUrl,
+                            modifier = Modifier.padding(20.dp).animateItem(),
+                            onVote = { id, opt -> onIntent(HomeIntent.OnVoteClicked(id, opt)) },
+                            onDelete = { id -> onIntent(HomeIntent.OnDeleteClicked(id)) },
+                            onReport = { id -> onIntent(HomeIntent.OnReportClicked(id)) },
+                        )
+                    }
+
+                    // 다음 페이지 로딩 중일 때 표시
+                    if (uiState.isNextPageLoading) {
+                        item {
+                            Box(
+                                modifier =
+                                    Modifier
+                                        .fillMaxWidth()
+                                        .padding(vertical = 16.dp),
+                                contentAlignment = Alignment.Center,
+                            ) {
+                                CircularProgressIndicator(
+                                    color = BuyOrNotTheme.colors.gray900,
+                                    strokeWidth = 2.dp,
+                                )
+                            }
                         }
                     }
                 }
-            }
 
-            // 2. 로딩 중인 단계 (로딩이 끝나기 전까지는 Result를 판단하지 않음)
-            uiState.isLoading -> {
-                item {
-                    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                        CircularProgressIndicator(color = BuyOrNotTheme.colors.gray900)
+                // 2. 로딩 중인 단계 (로딩이 끝나기 전까지는 Result를 판단하지 않음)
+                uiState.isLoading -> {
+                    item {
+                        Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                            CircularProgressIndicator(color = BuyOrNotTheme.colors.gray900)
+                        }
                     }
                 }
-            }
 
-            // 3. 로딩이 끝난 단계 (isLoading == false)
-            uiState.hasError -> {
-                // 통신 실패로 로딩이 끝난 경우
-                item {
-                    BuyOrNotErrorView(
-                        modifier = Modifier.padding(top = 80.dp),
-                        message = "피드를 불러오지 못했어요",
-                        onRefreshClick = { onIntent(HomeIntent.LoadFeeds) },
-                    )
+                // 3. 로딩이 끝난 단계 (isLoading == false)
+                uiState.hasError -> {
+                    // 통신 실패로 로딩이 끝난 경우
+                    item {
+                        BuyOrNotErrorView(
+                            modifier = Modifier.padding(top = 80.dp),
+                            message = "피드를 불러오지 못했어요",
+                            onRefreshClick = { onIntent(HomeIntent.LoadFeeds) },
+                        )
+                    }
                 }
-            }
 
-            else -> {
-                // [요청사항] 통신은 성공(hasError false)했지만 데이터가 없는 경우
-                item {
-                    HomeFeedEmptyView(
-                        modifier = Modifier.padding(top = 80.dp),
-                    )
+                else -> {
+                    // [요청사항] 통신은 성공(hasError false)했지만 데이터가 없는 경우
+                    item {
+                        HomeFeedEmptyView(
+                            modifier = Modifier.padding(top = 80.dp),
+                        )
+                    }
                 }
             }
         }

--- a/feature/home/src/main/java/com/sseotdabwa/buyornot/feature/home/ui/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/sseotdabwa/buyornot/feature/home/ui/HomeViewModel.kt
@@ -119,6 +119,7 @@ class HomeViewModel @Inject constructor(
             is HomeIntent.OnReportClicked -> handleReport(intent.feedId)
             is HomeIntent.LoadFeeds -> loadFeeds()
             is HomeIntent.LoadNextPage -> handleNextPage()
+            is HomeIntent.Refresh -> handleRefresh()
         }
     }
 
@@ -346,6 +347,39 @@ class HomeViewModel @Inject constructor(
                         icon = null,
                     ),
                 )
+            }
+        }
+    }
+
+    private fun handleRefresh() {
+        if (currentState.isRefreshing) return
+
+        viewModelScope.launch {
+            updateState { it.copy(isRefreshing = true, hasError = false) }
+            cachedFeeds = emptyList()
+
+            val currentTab = currentState.selectedTab
+            runCatchingCancellable {
+                when (currentTab) {
+                    HomeTab.FEED -> feedRepository.getFeedList(feedStatus = null)
+                    HomeTab.MY_FEED -> feedRepository.getMyFeeds(feedStatus = null)
+                }
+            }.onSuccess { feedList ->
+                cachedFeeds = feedList.feeds.map { feed ->
+                    val isOwner = currentUserId != null && feed.author.userId == currentUserId
+                    feed.toFeedItem(isOwner)
+                }
+                updateState {
+                    it.copy(
+                        isRefreshing = false,
+                        hasNextPage = feedList.hasNext,
+                        nextCursor = feedList.nextCursor,
+                    )
+                }
+                applyFiltering(currentTab)
+            }.onFailure { e ->
+                Log.e("HomeViewModel", "Failed to refresh feeds", e)
+                updateState { it.copy(isRefreshing = false, hasError = true) }
             }
         }
     }

--- a/feature/home/src/main/java/com/sseotdabwa/buyornot/feature/home/ui/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/sseotdabwa/buyornot/feature/home/ui/HomeViewModel.kt
@@ -130,7 +130,14 @@ class HomeViewModel @Inject constructor(
     }
 
     private fun handleFilterSelection(filter: FilterChip) {
-        updateState { it.copy(selectedFilter = filter, hasError = false) }
+        updateState {
+            it.copy(
+                selectedFilter = filter,
+                hasError = false,
+                hasNextPage = false,
+                nextCursor = null,
+            )
+        }
         loadFeeds(clearFeeds = false)
     }
 

--- a/feature/home/src/main/java/com/sseotdabwa/buyornot/feature/home/ui/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/sseotdabwa/buyornot/feature/home/ui/HomeViewModel.kt
@@ -203,55 +203,41 @@ class HomeViewModel @Inject constructor(
         feedId: String,
         optionIndex: Int,
     ) {
+        val targetFeed = cachedFeeds.find { it.id == feedId } ?: return
+
+        // 투표 불가 조건: 본인 글, 마감된 투표, 이미 투표한 피드
+        when {
+            targetFeed.isOwner -> {
+                sendSideEffect(
+                    HomeSideEffect.ShowSnackbar(
+                        message = "자신의 글에는 투표할 수 없습니다.",
+                        icon = null,
+                    ),
+                )
+                return
+            }
+            targetFeed.isVoteEnded -> return
+            targetFeed.userVotedOptionIndex != null -> return
+        }
+
         val previousFeeds = uiState.value.feeds
         val previousCachedFeeds = cachedFeeds
 
-        // 본인 글 여부 확인 (투표 방지)
-        val targetFeed = cachedFeeds.find { it.id == feedId }
-        if (targetFeed?.isOwner == true) {
-            sendSideEffect(
-                HomeSideEffect.ShowSnackbar(
-                    message = "자신의 글에는 투표할 수 없습니다.",
-                    icon = null,
-                ),
-            )
-            return
-        }
-
         // 1. 낙관적 업데이트 (Optimistic Update)
-        // API 호출 전 UI를 즉시 업데이트하여 사용자 경험 개선
-        val optimisticUpdate = { feeds: List<FeedItem> ->
-            feeds.map { feed ->
-                if (feed.id == feedId) {
-                    val isYes = optionIndex == 0
-                    feed.copy(
-                        userVotedOptionIndex = optionIndex,
-                        buyVoteCount = if (isYes) feed.buyVoteCount + 1 else feed.buyVoteCount,
-                        maybeVoteCount = if (!isYes) feed.maybeVoteCount + 1 else feed.maybeVoteCount,
-                        totalVoteCount = feed.totalVoteCount + 1,
-                    )
-                } else {
-                    feed
-                }
-            }
-        }
-
-        updateState { it.copy(feeds = optimisticUpdate(it.feeds)) }
-        cachedFeeds = optimisticUpdate(cachedFeeds)
+        updateState { it.copy(feeds = optimisticVoteUpdate(it.feeds, feedId, optionIndex)) }
+        cachedFeeds = optimisticVoteUpdate(cachedFeeds, feedId, optionIndex)
 
         viewModelScope.launch {
-            // optionIndex: 0 = YES, 1 = NO
             val choice = if (optionIndex == 0) VoteChoice.YES else VoteChoice.NO
 
             runCatchingCancellable {
-                // 사용자 타입에 따라 회원/비회원 투표 API 호출
                 when (uiState.value.userType) {
                     UserType.SOCIAL -> feedRepository.voteFeed(feedId.toLong(), choice)
                     UserType.GUEST -> feedRepository.voteGuestFeed(feedId.toLong(), choice)
                 }
             }.onSuccess { voteResult ->
-                // 2. 최종 업데이트: 서버 응답 데이터를 기반으로 UI 확정
-                val finalUpdate = { feeds: List<FeedItem> ->
+                // 2. 최종 업데이트: 서버 응답으로 확정
+                val confirmedFeeds = { feeds: List<FeedItem> ->
                     feeds.map { feed ->
                         if (feed.id == feedId) {
                             feed.copy(
@@ -265,16 +251,14 @@ class HomeViewModel @Inject constructor(
                         }
                     }
                 }
-
-                updateState { it.copy(feeds = finalUpdate(it.feeds)) }
-                cachedFeeds = finalUpdate(cachedFeeds)
+                updateState { it.copy(feeds = confirmedFeeds(it.feeds)) }
+                cachedFeeds = confirmedFeeds(cachedFeeds)
             }.onFailure { e ->
                 Log.e("HomeViewModel", "Failed to vote feed: $feedId", e)
-                // 3. 롤백 (Rollback): 에러 발생 시 원래 상태로 복구
+                // 3. 롤백 (Rollback)
                 updateState { it.copy(feeds = previousFeeds) }
                 cachedFeeds = previousCachedFeeds
 
-                // 에러 발생 시 스낵바로 알림
                 val errorMessage =
                     when {
                         e.message?.contains("400") == true -> "이미 투표했거나 마감된 피드입니다."
@@ -290,6 +274,22 @@ class HomeViewModel @Inject constructor(
             }
         }
     }
+
+    private fun optimisticVoteUpdate(
+        feeds: List<FeedItem>,
+        feedId: String,
+        optionIndex: Int,
+    ): List<FeedItem> =
+        feeds.map { feed ->
+            if (feed.id != feedId) return@map feed
+            val isYes = optionIndex == 0
+            feed.copy(
+                userVotedOptionIndex = optionIndex,
+                buyVoteCount = if (isYes) feed.buyVoteCount + 1 else feed.buyVoteCount,
+                maybeVoteCount = if (!isYes) feed.maybeVoteCount + 1 else feed.maybeVoteCount,
+                totalVoteCount = feed.totalVoteCount + 1,
+            )
+        }
 
     private fun handleDelete(feedId: String) {
         viewModelScope.launch {

--- a/feature/home/src/main/java/com/sseotdabwa/buyornot/feature/home/ui/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/sseotdabwa/buyornot/feature/home/ui/HomeViewModel.kt
@@ -28,9 +28,8 @@ class HomeViewModel @Inject constructor(
     private val feedRepository: FeedRepository,
     private val userRepository: UserRepository,
 ) : BaseViewModel<HomeUiState, HomeIntent, HomeSideEffect>(HomeUiState()) {
-    private var cachedFeeds: List<FeedItem> = emptyList()
     private var currentUserId: Long? = null
-    private var isUserIdLoaded = false // ID 로드 완료 여부 추적
+    private var isUserIdLoaded = false
 
     init {
         observeUserPreferences()
@@ -56,9 +55,8 @@ class HomeViewModel @Inject constructor(
                         } else {
                             currentUserId = null
                             isUserIdLoaded = true
-                            // 게스트 전환 시 탭을 무조건 FEED로 변경
                             updateState { it.copy(selectedTab = HomeTab.FEED) }
-                            loadFeeds(HomeTab.FEED)
+                            loadFeeds(tab = HomeTab.FEED)
                         }
                         lastUserType = userType
                     }
@@ -66,22 +64,14 @@ class HomeViewModel @Inject constructor(
         }
     }
 
-    /**
-     * 초기 데이터 로드: 사용자 ID를 먼저 로드한 후 피드 로드
-     */
     private fun loadInitialData() {
         viewModelScope.launch {
-            // 먼저 사용자 ID를 동기적으로 로드
             loadCurrentUserIdSuspend()
             isUserIdLoaded = true
-            // 사용자 ID 로드 완료 후 피드 로드
             loadFeeds()
         }
     }
 
-    /**
-     * suspend 함수로 사용자 ID를 동기적으로 로드
-     */
     private suspend fun loadCurrentUserIdSuspend() {
         runCatchingCancellable {
             if (uiState.value.userType == UserType.SOCIAL) {
@@ -104,7 +94,6 @@ class HomeViewModel @Inject constructor(
         viewModelScope.launch {
             loadCurrentUserIdSuspend()
             isUserIdLoaded = true
-            // 사용자 ID 로드 완료 후 피드 갱신
             loadFeeds()
         }
     }
@@ -124,7 +113,6 @@ class HomeViewModel @Inject constructor(
     }
 
     private fun handleTabSelection(tab: HomeTab) {
-        // 게스트일 때는 내 투표 탭 선택 불가
         if (uiState.value.userType == UserType.GUEST && tab == HomeTab.MY_FEED) return
 
         updateState {
@@ -138,14 +126,21 @@ class HomeViewModel @Inject constructor(
                 isNextPageLoading = false,
             )
         }
-        cachedFeeds = emptyList()
-        // 탭이 변경되므로 loadFeeds에 명시적으로 탭을 전달
-        loadFeeds(tab)
+        loadFeeds(tab = tab)
     }
 
     private fun handleFilterSelection(filter: FilterChip) {
-        updateState { it.copy(selectedFilter = filter, hasError = false) }
-        applyFiltering()
+        updateState {
+            it.copy(
+                selectedFilter = filter,
+                isLoading = true,
+                hasError = false,
+                feeds = emptyList(),
+                hasNextPage = false,
+                nextCursor = null,
+            )
+        }
+        loadFeeds()
     }
 
     private fun handleBannerDismiss() {
@@ -158,18 +153,19 @@ class HomeViewModel @Inject constructor(
         viewModelScope.launch {
             updateState { it.copy(isNextPageLoading = true) }
             val requestedTab = currentState.selectedTab
+            val requestedFilter = currentState.selectedFilter
 
             runCatchingCancellable {
                 when (requestedTab) {
                     HomeTab.FEED ->
                         feedRepository.getFeedList(
                             cursor = currentState.nextCursor,
-                            feedStatus = null,
+                            feedStatus = requestedFilter.toFeedStatus(),
                         )
                     HomeTab.MY_FEED ->
                         feedRepository.getMyFeeds(
                             cursor = currentState.nextCursor,
-                            feedStatus = null,
+                            feedStatus = requestedFilter.toFeedStatus(),
                         )
                 }
             }.onSuccess { feedList ->
@@ -178,21 +174,19 @@ class HomeViewModel @Inject constructor(
                     return@launch
                 }
 
-                val newItems =
-                    feedList.feeds.map { feed ->
-                        val isOwner = currentUserId != null && feed.author.userId == currentUserId
-                        feed.toFeedItem(isOwner)
-                    }
-                cachedFeeds = cachedFeeds + newItems
+                val newItems = feedList.feeds.map { feed ->
+                    val isOwner = currentUserId != null && feed.author.userId == currentUserId
+                    feed.toFeedItem(isOwner)
+                }
 
                 updateState {
                     it.copy(
+                        feeds = it.feeds + newItems,
                         isNextPageLoading = false,
                         hasNextPage = feedList.hasNext,
                         nextCursor = feedList.nextCursor,
                     )
                 }
-                applyFiltering()
             }.onFailure { e ->
                 Log.e("HomeViewModel", "Failed to load next page", e)
                 updateState { it.copy(isNextPageLoading = false) }
@@ -204,9 +198,8 @@ class HomeViewModel @Inject constructor(
         feedId: String,
         optionIndex: Int,
     ) {
-        val targetFeed = cachedFeeds.find { it.id == feedId } ?: return
+        val targetFeed = uiState.value.feeds.find { it.id == feedId } ?: return
 
-        // 투표 불가 조건: 본인 글, 마감된 투표, 이미 투표한 피드
         when {
             targetFeed.isOwner -> {
                 sendSideEffect(
@@ -222,11 +215,9 @@ class HomeViewModel @Inject constructor(
         }
 
         val previousFeeds = uiState.value.feeds
-        val previousCachedFeeds = cachedFeeds
 
         // 1. 낙관적 업데이트 (Optimistic Update)
         updateState { it.copy(feeds = optimisticVoteUpdate(it.feeds, feedId, optionIndex)) }
-        cachedFeeds = optimisticVoteUpdate(cachedFeeds, feedId, optionIndex)
 
         viewModelScope.launch {
             val choice = if (optionIndex == 0) VoteChoice.YES else VoteChoice.NO
@@ -238,27 +229,26 @@ class HomeViewModel @Inject constructor(
                 }
             }.onSuccess { voteResult ->
                 // 2. 최종 업데이트: 서버 응답으로 확정
-                val confirmedFeeds = { feeds: List<FeedItem> ->
-                    feeds.map { feed ->
-                        if (feed.id == feedId) {
-                            feed.copy(
-                                userVotedOptionIndex = optionIndex,
-                                buyVoteCount = voteResult.yesCount,
-                                maybeVoteCount = voteResult.noCount,
-                                totalVoteCount = voteResult.totalCount,
-                            )
-                        } else {
-                            feed
-                        }
-                    }
+                updateState {
+                    it.copy(
+                        feeds = it.feeds.map { feed ->
+                            if (feed.id == feedId) {
+                                feed.copy(
+                                    userVotedOptionIndex = optionIndex,
+                                    buyVoteCount = voteResult.yesCount,
+                                    maybeVoteCount = voteResult.noCount,
+                                    totalVoteCount = voteResult.totalCount,
+                                )
+                            } else {
+                                feed
+                            }
+                        },
+                    )
                 }
-                updateState { it.copy(feeds = confirmedFeeds(it.feeds)) }
-                cachedFeeds = confirmedFeeds(cachedFeeds)
             }.onFailure { e ->
                 Log.e("HomeViewModel", "Failed to vote feed: $feedId", e)
                 // 3. 롤백 (Rollback)
                 updateState { it.copy(feeds = previousFeeds) }
-                cachedFeeds = previousCachedFeeds
 
                 val errorMessage =
                     when {
@@ -297,13 +287,7 @@ class HomeViewModel @Inject constructor(
             runCatchingCancellable {
                 feedRepository.deleteFeed(feedId.toLong())
             }.onSuccess {
-                // UI에서 피드 제거
-                val updatedFeeds = uiState.value.feeds.filter { it.id != feedId }
-                updateState { it.copy(feeds = updatedFeeds) }
-
-                // 캐시에서도 제거
-                cachedFeeds = cachedFeeds.filter { it.id != feedId }
-
+                updateState { it.copy(feeds = it.feeds.filter { feed -> feed.id != feedId }) }
                 sendSideEffect(
                     HomeSideEffect.ShowSnackbar(
                         message = "삭제가 완료되었습니다.",
@@ -335,7 +319,6 @@ class HomeViewModel @Inject constructor(
                 )
             }.onFailure { e ->
                 Log.e("HomeViewModel", "Failed to report feed: $feedId", e)
-                // 400 에러 (본인 피드 또는 이미 신고된 피드)에 대한 처리
                 val errorMessage =
                     when {
                         e.message?.contains("400") == true -> "이미 신고한 피드이거나 본인의 피드입니다."
@@ -351,41 +334,10 @@ class HomeViewModel @Inject constructor(
         }
     }
 
-    private fun handleRefresh() {
-        if (currentState.isRefreshing) return
-
-        viewModelScope.launch {
-            updateState { it.copy(isRefreshing = true, hasError = false) }
-            cachedFeeds = emptyList()
-
-            val currentTab = currentState.selectedTab
-            runCatchingCancellable {
-                when (currentTab) {
-                    HomeTab.FEED -> feedRepository.getFeedList(feedStatus = null)
-                    HomeTab.MY_FEED -> feedRepository.getMyFeeds(feedStatus = null)
-                }
-            }.onSuccess { feedList ->
-                cachedFeeds = feedList.feeds.map { feed ->
-                    val isOwner = currentUserId != null && feed.author.userId == currentUserId
-                    feed.toFeedItem(isOwner)
-                }
-                updateState {
-                    it.copy(
-                        isRefreshing = false,
-                        hasNextPage = feedList.hasNext,
-                        nextCursor = feedList.nextCursor,
-                    )
-                }
-                applyFiltering(currentTab)
-            }.onFailure { e ->
-                Log.e("HomeViewModel", "Failed to refresh feeds", e)
-                updateState { it.copy(isRefreshing = false, hasError = true) }
-            }
-        }
-    }
-
     /**
      * 피드 데이터 로드 (API 연동)
+     * 탭/필터 변경 시 모두 API를 호출합니다.
+     *
      * @param tab 로드할 탭 (null이면 현재 선택된 탭 사용)
      */
     private fun loadFeeds(tab: HomeTab? = null) {
@@ -393,37 +345,31 @@ class HomeViewModel @Inject constructor(
             updateState { it.copy(isLoading = true, hasError = false) }
 
             runCatchingCancellable {
-                // ID가 아직 로드되지 않았으면 먼저 로드
                 if (!isUserIdLoaded && uiState.value.userType == UserType.SOCIAL) {
                     loadCurrentUserIdSuspend()
                     isUserIdLoaded = true
                 }
 
                 val currentTab = tab ?: uiState.value.selectedTab
-                // 필터 없이 해당 탭의 전체 데이터를 가져옴
+                val feedStatus = uiState.value.selectedFilter.toFeedStatus()
                 when (currentTab) {
-                    HomeTab.FEED -> feedRepository.getFeedList(feedStatus = null)
-                    HomeTab.MY_FEED -> feedRepository.getMyFeeds(feedStatus = null)
+                    HomeTab.FEED -> feedRepository.getFeedList(feedStatus = feedStatus)
+                    HomeTab.MY_FEED -> feedRepository.getMyFeeds(feedStatus = feedStatus)
                 }
             }.onSuccess { feedList ->
-                // 원본 데이터를 캐시에 저장
-                // 각 피드의 작성자 ID와 현재 사용자 ID를 비교하여 isOwner 설정
-                cachedFeeds =
-                    feedList.feeds.map { feed ->
-                        val isOwner = currentUserId != null && feed.author.userId == currentUserId
-                        feed.toFeedItem(isOwner)
-                    }
-
+                val feeds = feedList.feeds.map { feed ->
+                    val isOwner = currentUserId != null && feed.author.userId == currentUserId
+                    feed.toFeedItem(isOwner)
+                }
                 updateState {
                     it.copy(
+                        feeds = feeds,
+                        isLoading = false,
+                        hasError = false,
                         hasNextPage = feedList.hasNext,
                         nextCursor = feedList.nextCursor,
                     )
                 }
-
-                // 현재 선택된 필터에 맞춰 UI 상태 업데이트
-                // 탭 파라미터를 전달하여 즉시 반영되도록 함
-                applyFiltering(tab ?: uiState.value.selectedTab)
             }.onFailure { e ->
                 Log.e("HomeViewModel", "Failed to load feeds", e)
                 updateState { it.copy(isLoading = false, hasError = true) }
@@ -432,30 +378,51 @@ class HomeViewModel @Inject constructor(
     }
 
     /**
-     * 피드 필터링 적용
-     * @param tab 필터링할 탭 (null이면 현재 선택된 탭 사용)
+     * Pull To Refresh: API를 호출해 데이터를 갱신합니다.
+     * isLoading 대신 isRefreshing을 사용해 기존 피드를 유지한 채로 갱신합니다.
      */
-    private fun applyFiltering(tab: HomeTab? = null) {
-        val currentFilter = uiState.value.selectedFilter
-        val currentTab = tab ?: uiState.value.selectedTab
+    private fun handleRefresh() {
+        if (currentState.isRefreshing) return
 
-        // 1단계: 필터 칩에 따라 필터링
-        val chipFilteredList =
-            when (currentFilter) {
-                FilterChip.ALL -> cachedFeeds
-                FilterChip.IN_PROGRESS -> cachedFeeds.filter { !it.isVoteEnded }
-                FilterChip.ENDED -> cachedFeeds.filter { it.isVoteEnded }
+        viewModelScope.launch {
+            updateState { it.copy(isRefreshing = true, hasError = false) }
+
+            val currentTab = currentState.selectedTab
+            val feedStatus = currentState.selectedFilter.toFeedStatus()
+            runCatchingCancellable {
+                when (currentTab) {
+                    HomeTab.FEED -> feedRepository.getFeedList(feedStatus = feedStatus)
+                    HomeTab.MY_FEED -> feedRepository.getMyFeeds(feedStatus = feedStatus)
+                }
+            }.onSuccess { feedList ->
+                val feeds = feedList.feeds.map { feed ->
+                    val isOwner = currentUserId != null && feed.author.userId == currentUserId
+                    feed.toFeedItem(isOwner)
+                }
+                updateState {
+                    it.copy(
+                        feeds = feeds,
+                        isRefreshing = false,
+                        hasNextPage = feedList.hasNext,
+                        nextCursor = feedList.nextCursor,
+                    )
+                }
+            }.onFailure { e ->
+                Log.e("HomeViewModel", "Failed to refresh feeds", e)
+                updateState { it.copy(isRefreshing = false, hasError = true) }
             }
-
-        // 2단계: 탭에 따라 추가 필터링
-        val finalFilteredList =
-            when (currentTab) {
-                HomeTab.FEED -> chipFilteredList // 투표 피드: 모든 피드 표시
-                HomeTab.MY_FEED -> chipFilteredList.filter { it.isOwner } // 내 투표: 본인 피드만 표시
-            }
-
-        updateState { it.copy(feeds = finalFilteredList, isLoading = false, hasError = false) }
+        }
     }
+
+    /**
+     * FilterChip을 API feedStatus 파라미터로 변환
+     */
+    private fun FilterChip.toFeedStatus(): String? =
+        when (this) {
+            FilterChip.ALL -> null
+            FilterChip.IN_PROGRESS -> "OPEN"
+            FilterChip.ENDED -> "CLOSED"
+        }
 
     /**
      * Domain Feed를 UI FeedItem으로 변환

--- a/feature/home/src/main/java/com/sseotdabwa/buyornot/feature/home/ui/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/sseotdabwa/buyornot/feature/home/ui/HomeViewModel.kt
@@ -130,17 +130,8 @@ class HomeViewModel @Inject constructor(
     }
 
     private fun handleFilterSelection(filter: FilterChip) {
-        updateState {
-            it.copy(
-                selectedFilter = filter,
-                isLoading = true,
-                hasError = false,
-                feeds = emptyList(),
-                hasNextPage = false,
-                nextCursor = null,
-            )
-        }
-        loadFeeds()
+        updateState { it.copy(selectedFilter = filter, hasError = false) }
+        loadFeeds(clearFeeds = false)
     }
 
     private fun handleBannerDismiss() {
@@ -174,10 +165,11 @@ class HomeViewModel @Inject constructor(
                     return@launch
                 }
 
-                val newItems = feedList.feeds.map { feed ->
-                    val isOwner = currentUserId != null && feed.author.userId == currentUserId
-                    feed.toFeedItem(isOwner)
-                }
+                val newItems =
+                    feedList.feeds.map { feed ->
+                        val isOwner = currentUserId != null && feed.author.userId == currentUserId
+                        feed.toFeedItem(isOwner)
+                    }
 
                 updateState {
                     it.copy(
@@ -231,18 +223,19 @@ class HomeViewModel @Inject constructor(
                 // 2. 최종 업데이트: 서버 응답으로 확정
                 updateState {
                     it.copy(
-                        feeds = it.feeds.map { feed ->
-                            if (feed.id == feedId) {
-                                feed.copy(
-                                    userVotedOptionIndex = optionIndex,
-                                    buyVoteCount = voteResult.yesCount,
-                                    maybeVoteCount = voteResult.noCount,
-                                    totalVoteCount = voteResult.totalCount,
-                                )
-                            } else {
-                                feed
-                            }
-                        },
+                        feeds =
+                            it.feeds.map { feed ->
+                                if (feed.id == feedId) {
+                                    feed.copy(
+                                        userVotedOptionIndex = optionIndex,
+                                        buyVoteCount = voteResult.yesCount,
+                                        maybeVoteCount = voteResult.noCount,
+                                        totalVoteCount = voteResult.totalCount,
+                                    )
+                                } else {
+                                    feed
+                                }
+                            },
                     )
                 }
             }.onFailure { e ->
@@ -339,10 +332,18 @@ class HomeViewModel @Inject constructor(
      * 탭/필터 변경 시 모두 API를 호출합니다.
      *
      * @param tab 로드할 탭 (null이면 현재 선택된 탭 사용)
+     * @param clearFeeds true면 로딩 중 기존 피드를 비워 전체 로딩 UI 표시, false면 기존 피드 유지
      */
-    private fun loadFeeds(tab: HomeTab? = null) {
+    private fun loadFeeds(
+        tab: HomeTab? = null,
+        clearFeeds: Boolean = true,
+    ) {
         viewModelScope.launch {
-            updateState { it.copy(isLoading = true, hasError = false) }
+            if (clearFeeds) {
+                updateState { it.copy(isLoading = true, hasError = false, feeds = emptyList()) }
+            } else {
+                updateState { it.copy(hasError = false) }
+            }
 
             runCatchingCancellable {
                 if (!isUserIdLoaded && uiState.value.userType == UserType.SOCIAL) {
@@ -357,10 +358,11 @@ class HomeViewModel @Inject constructor(
                     HomeTab.MY_FEED -> feedRepository.getMyFeeds(feedStatus = feedStatus)
                 }
             }.onSuccess { feedList ->
-                val feeds = feedList.feeds.map { feed ->
-                    val isOwner = currentUserId != null && feed.author.userId == currentUserId
-                    feed.toFeedItem(isOwner)
-                }
+                val feeds =
+                    feedList.feeds.map { feed ->
+                        val isOwner = currentUserId != null && feed.author.userId == currentUserId
+                        feed.toFeedItem(isOwner)
+                    }
                 updateState {
                     it.copy(
                         feeds = feeds,
@@ -395,10 +397,11 @@ class HomeViewModel @Inject constructor(
                     HomeTab.MY_FEED -> feedRepository.getMyFeeds(feedStatus = feedStatus)
                 }
             }.onSuccess { feedList ->
-                val feeds = feedList.feeds.map { feed ->
-                    val isOwner = currentUserId != null && feed.author.userId == currentUserId
-                    feed.toFeedItem(isOwner)
-                }
+                val feeds =
+                    feedList.feeds.map { feed ->
+                        val isOwner = currentUserId != null && feed.author.userId == currentUserId
+                        feed.toFeedItem(isOwner)
+                    }
                 updateState {
                     it.copy(
                         feeds = feeds,

--- a/feature/home/src/main/java/com/sseotdabwa/buyornot/feature/home/ui/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/sseotdabwa/buyornot/feature/home/ui/HomeViewModel.kt
@@ -213,8 +213,6 @@ class HomeViewModel @Inject constructor(
             targetFeed.userVotedOptionIndex != null -> return
         }
 
-        val previousFeeds = uiState.value.feeds
-
         // 1. 낙관적 업데이트 (Optimistic Update)
         updateState { it.copy(feeds = optimisticVoteUpdate(it.feeds, feedId, optionIndex)) }
 
@@ -247,8 +245,15 @@ class HomeViewModel @Inject constructor(
                 }
             }.onFailure { e ->
                 Log.e("HomeViewModel", "Failed to vote feed: $feedId", e)
-                // 3. 롤백 (Rollback)
-                updateState { it.copy(feeds = previousFeeds) }
+                // 3. 롤백 (Rollback): 해당 피드만 원복, 나머지 동시 변경사항 보존
+                updateState {
+                    it.copy(
+                        feeds =
+                            it.feeds.map { feed ->
+                                if (feed.id == feedId) targetFeed else feed
+                            },
+                    )
+                }
 
                 val errorMessage =
                     when {

--- a/feature/mypage/src/main/java/com/sseotdabwa/buyornot/feature/mypage/ui/WithdrawalScreen.kt
+++ b/feature/mypage/src/main/java/com/sseotdabwa/buyornot/feature/mypage/ui/WithdrawalScreen.kt
@@ -67,6 +67,12 @@ fun WithdrawalRoute(
             onWithdrawalClick = {
                 viewModel.handleIntent(WithdrawalIntent.Withdraw(context))
             },
+            onShowWithdrawalDialog = {
+                viewModel.handleIntent(WithdrawalIntent.ShowWithdrawalDialog)
+            },
+            onDismissWithdrawalDialog = {
+                viewModel.handleIntent(WithdrawalIntent.DismissWithdrawalDialog)
+            },
             uiState = uiState,
         )
         if (uiState.isLoading) {

--- a/feature/upload/src/main/java/com/sseotdabwa/buyornot/feature/upload/ui/UploadScreen.kt
+++ b/feature/upload/src/main/java/com/sseotdabwa/buyornot/feature/upload/ui/UploadScreen.kt
@@ -114,7 +114,8 @@ fun UploadScreen(
         derivedStateOf {
             uiState.category != null &&
                 uiState.price.isNotEmpty() &&
-                uiState.selectedImageUri != null
+                uiState.selectedImageUri != null &&
+                !uiState.isLoading
         }
     }
 

--- a/feature/upload/src/main/java/com/sseotdabwa/buyornot/feature/upload/ui/UploadViewModel.kt
+++ b/feature/upload/src/main/java/com/sseotdabwa/buyornot/feature/upload/ui/UploadViewModel.kt
@@ -49,6 +49,8 @@ class UploadViewModel @Inject constructor(
     }
 
     private fun submitFeed(context: Context) {
+        if (currentState.isLoading) return
+
         val uri = currentState.selectedImageUri ?: return
         val category = currentState.category ?: return
         val price = currentState.price.toIntOrNull() ?: return


### PR DESCRIPTION
## 🛠 Related issue
[//]: # (해당하는 이슈 번호 달아주기)
closed #65 

어떤 변경사항이 있었나요?
- [x] 🐞 BugFix Something isn't working
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [x] ✨ Feature Feature
- [x] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (Junit, etc.)

## ✅ CheckPoint
[//]: # (PR 요구사항 확인)
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 컨벤션에 맞게 작성했습니다. (필수)
- [x] merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕) (필수)
- [x] Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다. (필수)
- [x] BugFix의 경우, 버그의 원인을 파악하였습니다. (선택)

## ✏️ Work Description
[//]: # (작업 내용 간단 소개)

### 🐞 BugFix

- **로그인 성공 시 백스택 미제거**
  - 원인: `onLoginSuccess`에서 `popUpTo(SPLASH_ROUTE)`를 사용했으나, `navigateToLogin()` 호출 시점에 이미 SPLASH_ROUTE가 백스택에서 제거된 상태라 AUTH_ROUTE가 잔류
  - 수정: `popUpTo(AUTH_ROUTE) { inclusive = true }`로 변경 (`BuyOrNotNavHost.kt`)

- **투표 피드 중복 업로드**
  - 원인: 업로드 버튼 활성화 조건에 `isLoading` 체크 누락
  - 수정: `uiState.isLoading` 중 업로드 버튼 비활성화 및 ViewModel에서 이중 호출 방어 (`UploadScreen.kt`, `UploadViewModel.kt`)

- **회원탈퇴 다이얼로그 미노출**
  - 원인: `WithdrawalScreen`에서 `onShowWithdrawalDialog` / `onDismissWithdrawalDialog` 콜백이 전달되지 않음
  - 수정: 누락된 콜백 연결 (`WithdrawalScreen.kt`)

- **투표 낙관적 업데이트 시 득표율 노출**
  - 원인: 낙관적 업데이트로 투표 수가 임시 변경될 때 투표 결과(득표율 바)가 노출됨
  - 수정: API 응답 확정 전까지 UI에 결과를 반영하지 않도록 처리 (`HomeViewModel.kt`)

### ✨ Feature

- Pull To Refresh 구현
   - `HomeUiState`에 `isRefreshing` 상태 추가
   - `HomeIntent.Refresh` 추가
   - Material3 `PullToRefreshBox`로 `LazyColumn` 감싸기
   - PTR 시 `isLoading`(전체 화면 스피너) 대신 `isRefreshing`을 사용해 기존 피드를 유지한 채로 갱신

- 필터 변경 시 깜빡임 방지
   - 필터 칩 선택 시 기존 피드 목록을 비우지 않고 유지(`clearFeeds = false`)
   - API 응답이 오면 조용히 교체 → 화면 깜빡임 최소화

### 🔨 Refactor

- **HomeScreen 헤더 구현 단순화**
  - 기존: `SubcomposeLayout`으로 TopBar·Tab 높이를 별도 측정 → `NestedScrollConnection` + `offset`으로 수동 제어
  - 변경: TopBar를 LazyColumn의 일반 `item`으로, Tab을 `stickyHeader`로 배치
  - 제거: `SubcomposeLayout`, `HomeHeader` composable, `NestedScrollConnection`, `topBarHeightPx`/`tabHeightPx` state (`HomeScreen.kt`)

- HomeViewModel 리팩토링
   - `cachedFeeds` 제거 → 탭/필터 변경 시 API를 직접 호출하도록 변경
   - `FilterChip.toFeedStatus()` 추가: 필터 칩 선택 값을 API `feedStatus` 파라미터(`"OPEN"` / `"CLOSED"` / `null`)로 변환하여 서버 사이드 필터링
   - `applyFiltering()` 제거 → `loadFeeds()` 내에서 결과를 바로 state에 반영

## 😅 Uncompleted Tasks
[//]: # (없다면 N/A)
N/A

## 📢 To Reviewers
[//]: # (reviewer가 알면 좋은 내용들)
클로드는 신이예요

## 📃 RCA 룰
- R: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
- C: 웬만하면 반영해 주세요. (Comment)
- A: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 업로드 중 중복 제출 방지 및 로딩 중 제출 버튼 비활성화
  * 투표 검증 강화 및 실패 시 해당 항목만 이전 상태로 복원

* **개선 사항**
  * 홈 화면 레이아웃 단순화, 피드 내 헤더 통합 및 스티키 탭 적용
  * 당겨서 새로고침 지원(isRefreshing/새로고침 동작 추가) 및 새로고침 UX 개선
  * 로그인 후 뒤로가기 동작 변경(로그인 후 백스택 처리 개선)
  * 스낵바가 하단 내비게이션 여백을 반영하도록 레이아웃 조정
  * 회원탈퇴 대화상자 제어 콜백 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->