### PR TITLE
Chore/#72 ktlint 자동 포맷팅 CI 워크플로우 추가

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   ktlint:
     runs-on: ubuntu-latest
+    if: github.actor != 'github-actions[bot]'
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -37,4 +37,31 @@ jobs:
         uses: gradle/actions/setup-gradle@v3
 
       - name: Run ktlint check
+        id: ktlint
         run: ./gradlew ktlintCheck
+        continue-on-error: true
+
+      - name: Auto-fix with ktlintFormat
+        if: steps.ktlint.outcome == 'failure'
+        run: ./gradlew ktlintFormat
+
+      - name: Commit and push ktlint fixes
+        if: steps.ktlint.outcome == 'failure'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          BRANCH="${GITHUB_HEAD_REF:-${GITHUB_REF_NAME}}"
+          ISSUE=$(echo "$BRANCH" | grep -oP '#\d+' | head -1)
+          if [ -n "$ISSUE" ]; then
+            MSG="chore/${ISSUE}: ktlint 포맷팅"
+          else
+            MSG="chore: ktlint 포맷팅"
+          fi
+          git diff --quiet || (git add -A && git commit -m "$MSG")
+          git push
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Fail if ktlint had errors
+        if: steps.ktlint.outcome == 'failure'
+        run: exit 1

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -41,12 +41,19 @@ jobs:
         run: ./gradlew ktlintCheck
         continue-on-error: true
 
-      - name: Auto-fix with ktlintFormat
-        if: steps.ktlint.outcome == 'failure'
+      - name: Fail with guide message (fork PR)
+        if: steps.ktlint.outcome == 'failure' && github.event.pull_request.head.repo.full_name != github.repository
+        run: |
+          echo "::error::ktlint 검사에 실패했습니다. Fork PR은 자동 포맷팅이 지원되지 않습니다."
+          echo "::error::로컬에서 ./gradlew ktlintFormat 실행 후 다시 push 해주세요."
+          exit 1
+
+      - name: Auto-fix with ktlintFormat (internal branch only)
+        if: steps.ktlint.outcome == 'failure' && github.event.pull_request.head.repo.full_name == github.repository
         run: ./gradlew ktlintFormat
 
-      - name: Commit and push ktlint fixes
-        if: steps.ktlint.outcome == 'failure'
+      - name: Commit and push ktlint fixes (internal branch only)
+        if: steps.ktlint.outcome == 'failure' && github.event.pull_request.head.repo.full_name == github.repository
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -62,6 +69,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Fail if ktlint had errors
-        if: steps.ktlint.outcome == 'failure'
+      - name: Fail if ktlint had errors (internal branch only)
+        if: steps.ktlint.outcome == 'failure' && github.event.pull_request.head.repo.full_name == github.repository
         run: exit 1


### PR DESCRIPTION
## 🛠 Related issue
[//]: # (해당하는 이슈 번호 달아주기)
closed #72 

어떤 변경사항이 있었나요?
- [ ] 🐞 BugFix Something isn't working
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [ ] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [x] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (Junit, etc.)

## ✅ CheckPoint
[//]: # (PR 요구사항 확인)
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 컨벤션에 맞게 작성했습니다. (필수)
- [x] merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕) (필수)
- [x] Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다. (필수)
- [ ] BugFix의 경우, 버그의 원인을 파악하였습니다. (선택)

## ✏️ Work Description
[//]: # (작업 내용 간단 소개)
 - ktlintCheck 실패 시 ktlintFormat으로 자동 수정
 - 브랜치명에서 이슈 번호 추출하여 커밋 메시지 자동 생성
 - 포맷팅 수정 내용 자동 커밋 및 푸시
   - 저장소 내부 PR일 경우에만 작동
   - Fork PR 시 자동 포맷팅이 안되기 때문에 안내 로그 메시지 남김

## 😅 Uncompleted Tasks
[//]: # (없다면 N/A)
N/A

## 📢 To Reviewers
[//]: # (reviewer가 알면 좋은 내용들)

## 📃 RCA 룰
- R: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
- C: 웬만하면 반영해 주세요. (Comment)
- A: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Android CI 린트 동작 개선: 내부 PR에서는 린트 실패 시 자동으로 포맷을 시도하고 변경사항을 커밋·푸시합니다.
  * 외부(포크) PR에서는 자동 포맷 대신 린트 실패로 워크플로우가 중단되며 안내 메시지가 표시됩니다.
  * 전체적으로 린트 문제는 CI 결과에 반영됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->