### PR TITLE
Feat/#94: 이미지 뷰어 좌우 이동 화살표 버튼 추가 및 FullScreen Dialog 전환

### DIFF
--- a/core/ui/src/main/java/com/sseotdabwa/buyornot/core/ui/imageviewer/ImageViewerNavigation.kt
+++ b/core/ui/src/main/java/com/sseotdabwa/buyornot/core/ui/imageviewer/ImageViewerNavigation.kt
@@ -1,8 +1,9 @@
 package com.sseotdabwa.buyornot.core.ui.imageviewer
 
+import androidx.compose.ui.window.DialogProperties
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
-import androidx.navigation.compose.composable
+import androidx.navigation.compose.dialog
 import androidx.navigation.toRoute
 import kotlinx.serialization.Serializable
 
@@ -20,7 +21,14 @@ fun NavController.navigateToImageViewer(
 }
 
 fun NavGraphBuilder.imageViewerScreen(onBackClick: () -> Unit) {
-    composable<ImageViewerRoute> { backStackEntry ->
+    dialog<ImageViewerRoute>(
+        dialogProperties =
+            DialogProperties(
+                usePlatformDefaultWidth = false,
+                decorFitsSystemWindows = false,
+                dismissOnClickOutside = false,
+            ),
+    ) { backStackEntry ->
         val route = backStackEntry.toRoute<ImageViewerRoute>()
         ImageViewerScreen(
             imageUrls = route.imageUrls,

--- a/core/ui/src/main/java/com/sseotdabwa/buyornot/core/ui/imageviewer/ImageViewerScreen.kt
+++ b/core/ui/src/main/java/com/sseotdabwa/buyornot/core/ui/imageviewer/ImageViewerScreen.kt
@@ -17,8 +17,10 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.CircleShape
@@ -116,6 +118,7 @@ fun ImageViewerScreen(
             modifier =
                 Modifier
                     .fillMaxWidth()
+                    .statusBarsPadding()
                     .height(60.dp),
             contentAlignment = Alignment.CenterStart,
         ) {
@@ -191,6 +194,7 @@ fun ImageViewerScreen(
             modifier =
                 Modifier
                     .fillMaxWidth()
+                    .navigationBarsPadding()
                     .height(60.dp),
         )
     }

--- a/core/ui/src/main/java/com/sseotdabwa/buyornot/core/ui/imageviewer/ImageViewerScreen.kt
+++ b/core/ui/src/main/java/com/sseotdabwa/buyornot/core/ui/imageviewer/ImageViewerScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -103,7 +104,7 @@ fun ImageViewerScreen(
             initialPage = initialPage,
             pageCount = { imageUrls.size },
         )
-    var isZoomed by remember { mutableStateOf(false) }
+    val scope = rememberCoroutineScope()
 
     Column(
         modifier =
@@ -136,15 +137,54 @@ fun ImageViewerScreen(
             }
         }
 
-        HorizontalPager(
-            state = pagerState,
-            modifier = Modifier.fillMaxSize().weight(1f),
-            userScrollEnabled = !isZoomed,
-        ) { page ->
-            ZoomableImage(
-                imageUrl = imageUrls[page],
-                onZoomChanged = { zoomed -> isZoomed = zoomed },
-            )
+        Box(modifier = Modifier.fillMaxSize().weight(1f)) {
+            HorizontalPager(
+                state = pagerState,
+                modifier = Modifier.fillMaxSize(),
+                userScrollEnabled = false,
+            ) { page ->
+                ZoomableImage(imageUrl = imageUrls[page])
+            }
+
+            if (pagerState.currentPage > 0) {
+                Box(
+                    modifier =
+                        Modifier
+                            .align(Alignment.CenterStart)
+                            .padding(start = 10.dp)
+                            .size(30.dp)
+                            .background(Color.Black.copy(alpha = 0.4f), CircleShape)
+                            .clickable { scope.launch { pagerState.animateScrollToPage(pagerState.currentPage - 1) } },
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Icon(
+                        imageVector = BuyOrNotIcons.ArrowLeft.asImageVector(),
+                        contentDescription = "이전 사진",
+                        tint = BuyOrNotTheme.colors.gray0,
+                        modifier = Modifier.size(14.dp),
+                    )
+                }
+            }
+
+            if (pagerState.currentPage < imageUrls.size - 1) {
+                Box(
+                    modifier =
+                        Modifier
+                            .align(Alignment.CenterEnd)
+                            .padding(end = 10.dp)
+                            .size(30.dp)
+                            .background(Color.Black.copy(alpha = 0.4f), CircleShape)
+                            .clickable { scope.launch { pagerState.animateScrollToPage(pagerState.currentPage + 1) } },
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Icon(
+                        imageVector = BuyOrNotIcons.ArrowRight.asImageVector(),
+                        contentDescription = "다음 사진",
+                        tint = BuyOrNotTheme.colors.gray0,
+                        modifier = Modifier.size(14.dp),
+                    )
+                }
+            }
         }
 
         Box(
@@ -157,10 +197,7 @@ fun ImageViewerScreen(
 }
 
 @Composable
-private fun ZoomableImage(
-    imageUrl: String,
-    onZoomChanged: (Boolean) -> Unit,
-) {
+private fun ZoomableImage(imageUrl: String) {
     var scale by remember { mutableFloatStateOf(1f) }
     var offset by remember { mutableStateOf(Offset.Zero) }
     var containerSize by remember { mutableStateOf(IntSize.Zero) }
@@ -176,7 +213,6 @@ private fun ZoomableImage(
                 onScaleChange = { scale = it },
                 onOffsetChange = { offset = it },
             )
-            onZoomChanged(false)
         }
     }
 
@@ -220,7 +256,6 @@ private fun ZoomableImage(
                                 )?.let { (maxX, maxY) ->
                                     Offset(rawOffset.x.coerceIn(-maxX, maxX), rawOffset.y.coerceIn(-maxY, maxY))
                                 } ?: rawOffset
-                                onZoomChanged(newScale > 1f)
                                 event.changes.forEach { if (it.positionChanged()) it.consume() }
                             }
                         } while (event.changes.any { it.pressed })
@@ -238,11 +273,9 @@ private fun ZoomableImage(
                                         onScaleChange = { scale = it },
                                         onOffsetChange = { offset = it },
                                     )
-                                    onZoomChanged(false)
                                 } else {
                                     scale = 2f
                                     offset = Offset.Zero
-                                    onZoomChanged(true)
                                 }
                             }
                         },


### PR DESCRIPTION
## 🛠 Related issue
closed #94

어떤 변경사항이 있었나요?
- [ ] 🐞 BugFix Something isn't working
- [x] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [x] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (Junit, etc.)

## ✅ CheckPoint
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 컨벤션에 맞게 작성했습니다. (필수)
- [x] merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕) (필수)
- [x] Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다. (필수)
- [ ] BugFix의 경우, 버그의 원인을 파악하였습니다. (선택)

## ✏️ Work Description
<img width="1080" height="2520" alt="image" src="https://github.com/user-attachments/assets/fdc23d09-66b7-406b-9825-5b52eee2b7d4" />
- `ImageViewerScreen`에 스와이프 대신 좌우 화살표 버튼 추가
  - 첫 번째 페이지에서 왼쪽 버튼 숨김, 마지막 페이지에서 오른쪽 버튼 숨김
  - 단일 이미지일 경우 양쪽 버튼 모두 숨김
  - 버튼: 검정 40% 투명도 CircleShape 30dp, 아이콘 14dp (gray0 tint)
- `ImageViewerScreen`을 Navigation Compose `dialog<T>`로 전환
  - HomeScreen 탭 선택 상태(투표 피드 / 내 투표)가 ImageViewer 복귀 시 초기화되는 문제 해결
  - `DialogProperties(usePlatformDefaultWidth = false, decorFitsSystemWindows = false, dismissOnClickOutside = false)` 적용
- `statusBarsPadding` / `navigationBarsPadding` 적용

## 😅 Uncompleted Tasks
- N/A

## 📢 To Reviewers
- Dialog 전환으로 `HomeRoute`가 composition에서 제거되지 않아 `LaunchedEffect(initialTab)` 재실행 없이 탭 상태가 보존됩니다.
- `decorFitsSystemWindows = false`로 검은 배경이 상태바까지 확장되며, `statusBarsPadding` / `navigationBarsPadding`으로 콘텐츠 영역을 안전 영역 안으로 밀어 넣었습니다.

## 📃 RCA 룰
- R: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
- C: 웬만하면 반영해 주세요. (Comment)
- A: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)