### PR TITLE
Feat/#99 HomeBanner 그림자 클리핑 버그 수정

### DIFF
--- a/feature/home/src/main/java/com/sseotdabwa/buyornot/feature/home/ui/HomeBanner.kt
+++ b/feature/home/src/main/java/com/sseotdabwa/buyornot/feature/home/ui/HomeBanner.kt
@@ -86,7 +86,7 @@ fun HomeBanner(
                     shape = RoundedCornerShape(HomeBannerDefaults.BannerCornerRadius),
                     shadow =
                         Shadow(
-                            radius = 25.dp,
+                            radius = 40.dp,
                             color = Color(0xFFE0E3E5).copy(alpha = 0.6f),
                             offset = DpOffset(x = 0.dp, y = 4.dp),
                         ),

--- a/feature/home/src/main/java/com/sseotdabwa/buyornot/feature/home/ui/HomeScreen.kt
+++ b/feature/home/src/main/java/com/sseotdabwa/buyornot/feature/home/ui/HomeScreen.kt
@@ -37,6 +37,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -52,6 +53,8 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -360,6 +363,11 @@ private fun HomeFeedList(
     val listState = rememberLazyListState()
     val isEmptyViewVisible = filteredFeeds.isEmpty() && !uiState.isLoading && !uiState.hasError
     val isMyFeedEmpty = uiState.selectedTab == HomeTab.MY_FEED && isEmptyViewVisible
+    var headerHeightPx by remember { mutableIntStateOf(0) }
+    val density = LocalDensity.current
+    val isAtTop by remember {
+        derivedStateOf { listState.firstVisibleItemIndex == 0 && listState.firstVisibleItemScrollOffset == 0 }
+    }
 
     var showLinkTooltip by remember { mutableStateOf(true) }
     val tooltipTargetIndex =
@@ -409,61 +417,16 @@ private fun HomeFeedList(
         onRefresh = { onIntent(HomeIntent.Refresh) },
         modifier = modifier.fillMaxSize(),
     ) {
-        Column(modifier = Modifier.fillMaxSize()) {
-            // 고정 헤더 영역 (TopBar + FilterChipRow는 스크롤 방향에 따라 표시/숨김, Tab은 항상 고정)
-            Column(
-                modifier =
-                    Modifier
-                        .fillMaxWidth()
-                        .padding(top = contentPadding.calculateTopPadding())
-                        .background(BuyOrNotTheme.colors.gray0),
-            ) {
-                AnimatedVisibility(
-                    visible = isHeaderVisible,
-                    enter = expandVertically(tween(300, easing = EaseOutCubic), expandFrom = Alignment.Top) + fadeIn(tween(300)),
-                    exit = shrinkVertically(tween(200, easing = EaseInCubic), shrinkTowards = Alignment.Top) + fadeOut(tween(200)),
-                ) {
-                    HomeTopBarSection(
-                        userType = uiState.userType,
-                        onLoginClick = onLoginClick,
-                        onNotificationClick = onNotificationClick,
-                        onProfileClick = onProfileClick,
-                    )
-                }
-
-                HomeTabSection(
-                    userType = uiState.userType,
-                    selectedTab = uiState.selectedTab,
-                    onTabSelected = { onIntent(HomeIntent.OnTabSelected(it)) },
-                )
-
-                AnimatedVisibility(
-                    visible = isHeaderVisible && !isMyFeedEmpty,
-                    enter = expandVertically(tween(300, easing = EaseOutCubic), expandFrom = Alignment.Top) + fadeIn(tween(300)),
-                    exit = shrinkVertically(tween(200, easing = EaseInCubic), shrinkTowards = Alignment.Top) + fadeOut(tween(200)),
-                ) {
-                    Column {
-                        Spacer(modifier = Modifier.height(10.dp))
-                        FilterChipRow(
-                            selectedCategories = uiState.selectedCategories,
-                            onAllCategorySelected = { onIntent(HomeIntent.OnAllCategorySelected) },
-                            onCategoryToggled = { onIntent(HomeIntent.OnCategoryToggled(it)) },
-                            selectedFilter = uiState.selectedFilter,
-                            onShowSortSheet = { onIntent(HomeIntent.ShowSortSheet) },
-                        )
-                        Spacer(modifier = Modifier.height(10.dp))
-                    }
-                }
-            }
-
-            // 스크롤 가능한 피드 목록
+        Box(modifier = Modifier.fillMaxSize()) {
+            // 스크롤 가능한 피드 목록 (헤더 오버레이 아래에 렌더링)
             LazyColumn(
                 state = listState,
-                modifier =
-                    Modifier
-                        .fillMaxWidth()
-                        .weight(1f),
-                contentPadding = PaddingValues(bottom = contentPadding.calculateBottomPadding()),
+                modifier = Modifier.fillMaxSize(),
+                contentPadding =
+                    PaddingValues(
+                        top = with(density) { headerHeightPx.toDp() },
+                        bottom = contentPadding.calculateBottomPadding(),
+                    ),
                 horizontalAlignment = Alignment.CenterHorizontally,
             ) {
                 // 배너 (투표 피드 탭이고 isBannerVisible이 true일 때만 표시)
@@ -557,6 +520,59 @@ private fun HomeFeedList(
                                 )
                             }
                         }
+                    }
+                }
+            }
+
+            // 고정 헤더 영역 (오버레이: LazyColumn 위에 렌더링)
+            Column(
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(top = contentPadding.calculateTopPadding())
+                        .onGloballyPositioned { headerHeightPx = it.size.height },
+            ) {
+                Column(modifier = Modifier.background(BuyOrNotTheme.colors.gray0)) {
+                    AnimatedVisibility(
+                        visible = isHeaderVisible,
+                        enter = expandVertically(tween(300, easing = EaseOutCubic), expandFrom = Alignment.Top) + fadeIn(tween(300)),
+                        exit = shrinkVertically(tween(200, easing = EaseInCubic), shrinkTowards = Alignment.Top) + fadeOut(tween(200)),
+                    ) {
+                        HomeTopBarSection(
+                            userType = uiState.userType,
+                            onLoginClick = onLoginClick,
+                            onNotificationClick = onNotificationClick,
+                            onProfileClick = onProfileClick,
+                        )
+                    }
+
+                    HomeTabSection(
+                        userType = uiState.userType,
+                        selectedTab = uiState.selectedTab,
+                        onTabSelected = { onIntent(HomeIntent.OnTabSelected(it)) },
+                    )
+                }
+
+                AnimatedVisibility(
+                    visible = isHeaderVisible && !isMyFeedEmpty,
+                    enter = expandVertically(tween(300, easing = EaseOutCubic), expandFrom = Alignment.Top) + fadeIn(tween(300)),
+                    exit = shrinkVertically(tween(200, easing = EaseInCubic), shrinkTowards = Alignment.Top) + fadeOut(tween(200)),
+                ) {
+                    Column(
+                        modifier =
+                            Modifier.background(
+                                if (isAtTop) Color.Transparent else BuyOrNotTheme.colors.gray0,
+                            ),
+                    ) {
+                        Spacer(modifier = Modifier.height(10.dp))
+                        FilterChipRow(
+                            selectedCategories = uiState.selectedCategories,
+                            onAllCategorySelected = { onIntent(HomeIntent.OnAllCategorySelected) },
+                            onCategoryToggled = { onIntent(HomeIntent.OnCategoryToggled(it)) },
+                            selectedFilter = uiState.selectedFilter,
+                            onShowSortSheet = { onIntent(HomeIntent.ShowSortSheet) },
+                        )
+                        Spacer(modifier = Modifier.height(10.dp))
                     }
                 }
             }

--- a/feature/home/src/main/java/com/sseotdabwa/buyornot/feature/home/ui/HomeScreen.kt
+++ b/feature/home/src/main/java/com/sseotdabwa/buyornot/feature/home/ui/HomeScreen.kt
@@ -360,9 +360,6 @@ private fun HomeFeedList(
     val listState = rememberLazyListState()
     val isEmptyViewVisible = filteredFeeds.isEmpty() && !uiState.isLoading && !uiState.hasError
     val isMyFeedEmpty = uiState.selectedTab == HomeTab.MY_FEED && isEmptyViewVisible
-    val isAtTop by remember {
-        derivedStateOf { listState.firstVisibleItemIndex == 0 && listState.firstVisibleItemScrollOffset == 0 }
-    }
 
     var showLinkTooltip by remember { mutableStateOf(true) }
     val tooltipTargetIndex =
@@ -418,40 +415,34 @@ private fun HomeFeedList(
                 modifier =
                     Modifier
                         .fillMaxWidth()
-                        .padding(top = contentPadding.calculateTopPadding()),
+                        .padding(top = contentPadding.calculateTopPadding())
+                        .background(BuyOrNotTheme.colors.gray0),
             ) {
-                Column(modifier = Modifier.background(BuyOrNotTheme.colors.gray0)) {
-                    AnimatedVisibility(
-                        visible = isHeaderVisible,
-                        enter = expandVertically(tween(300, easing = EaseOutCubic), expandFrom = Alignment.Top) + fadeIn(tween(300)),
-                        exit = shrinkVertically(tween(200, easing = EaseInCubic), shrinkTowards = Alignment.Top) + fadeOut(tween(200)),
-                    ) {
-                        HomeTopBarSection(
-                            userType = uiState.userType,
-                            onLoginClick = onLoginClick,
-                            onNotificationClick = onNotificationClick,
-                            onProfileClick = onProfileClick,
-                        )
-                    }
-
-                    HomeTabSection(
+                AnimatedVisibility(
+                    visible = isHeaderVisible,
+                    enter = expandVertically(tween(300, easing = EaseOutCubic), expandFrom = Alignment.Top) + fadeIn(tween(300)),
+                    exit = shrinkVertically(tween(200, easing = EaseInCubic), shrinkTowards = Alignment.Top) + fadeOut(tween(200)),
+                ) {
+                    HomeTopBarSection(
                         userType = uiState.userType,
-                        selectedTab = uiState.selectedTab,
-                        onTabSelected = { onIntent(HomeIntent.OnTabSelected(it)) },
+                        onLoginClick = onLoginClick,
+                        onNotificationClick = onNotificationClick,
+                        onProfileClick = onProfileClick,
                     )
                 }
+
+                HomeTabSection(
+                    userType = uiState.userType,
+                    selectedTab = uiState.selectedTab,
+                    onTabSelected = { onIntent(HomeIntent.OnTabSelected(it)) },
+                )
 
                 AnimatedVisibility(
                     visible = isHeaderVisible && !isMyFeedEmpty,
                     enter = expandVertically(tween(300, easing = EaseOutCubic), expandFrom = Alignment.Top) + fadeIn(tween(300)),
                     exit = shrinkVertically(tween(200, easing = EaseInCubic), shrinkTowards = Alignment.Top) + fadeOut(tween(200)),
                 ) {
-                    Column(
-                        modifier =
-                            Modifier.background(
-                                if (isAtTop) Color.Transparent else BuyOrNotTheme.colors.gray0,
-                            ),
-                    ) {
+                    Column {
                         Spacer(modifier = Modifier.height(10.dp))
                         FilterChipRow(
                             selectedCategories = uiState.selectedCategories,

--- a/feature/home/src/main/java/com/sseotdabwa/buyornot/feature/home/ui/HomeScreen.kt
+++ b/feature/home/src/main/java/com/sseotdabwa/buyornot/feature/home/ui/HomeScreen.kt
@@ -360,6 +360,9 @@ private fun HomeFeedList(
     val listState = rememberLazyListState()
     val isEmptyViewVisible = filteredFeeds.isEmpty() && !uiState.isLoading && !uiState.hasError
     val isMyFeedEmpty = uiState.selectedTab == HomeTab.MY_FEED && isEmptyViewVisible
+    val isAtTop by remember {
+        derivedStateOf { listState.firstVisibleItemIndex == 0 && listState.firstVisibleItemScrollOffset == 0 }
+    }
 
     var showLinkTooltip by remember { mutableStateOf(true) }
     val tooltipTargetIndex =
@@ -415,34 +418,40 @@ private fun HomeFeedList(
                 modifier =
                     Modifier
                         .fillMaxWidth()
-                        .padding(top = contentPadding.calculateTopPadding())
-                        .background(BuyOrNotTheme.colors.gray0),
+                        .padding(top = contentPadding.calculateTopPadding()),
             ) {
-                AnimatedVisibility(
-                    visible = isHeaderVisible,
-                    enter = expandVertically(tween(300, easing = EaseOutCubic), expandFrom = Alignment.Top) + fadeIn(tween(300)),
-                    exit = shrinkVertically(tween(200, easing = EaseInCubic), shrinkTowards = Alignment.Top) + fadeOut(tween(200)),
-                ) {
-                    HomeTopBarSection(
+                Column(modifier = Modifier.background(BuyOrNotTheme.colors.gray0)) {
+                    AnimatedVisibility(
+                        visible = isHeaderVisible,
+                        enter = expandVertically(tween(300, easing = EaseOutCubic), expandFrom = Alignment.Top) + fadeIn(tween(300)),
+                        exit = shrinkVertically(tween(200, easing = EaseInCubic), shrinkTowards = Alignment.Top) + fadeOut(tween(200)),
+                    ) {
+                        HomeTopBarSection(
+                            userType = uiState.userType,
+                            onLoginClick = onLoginClick,
+                            onNotificationClick = onNotificationClick,
+                            onProfileClick = onProfileClick,
+                        )
+                    }
+
+                    HomeTabSection(
                         userType = uiState.userType,
-                        onLoginClick = onLoginClick,
-                        onNotificationClick = onNotificationClick,
-                        onProfileClick = onProfileClick,
+                        selectedTab = uiState.selectedTab,
+                        onTabSelected = { onIntent(HomeIntent.OnTabSelected(it)) },
                     )
                 }
-
-                HomeTabSection(
-                    userType = uiState.userType,
-                    selectedTab = uiState.selectedTab,
-                    onTabSelected = { onIntent(HomeIntent.OnTabSelected(it)) },
-                )
 
                 AnimatedVisibility(
                     visible = isHeaderVisible && !isMyFeedEmpty,
                     enter = expandVertically(tween(300, easing = EaseOutCubic), expandFrom = Alignment.Top) + fadeIn(tween(300)),
                     exit = shrinkVertically(tween(200, easing = EaseInCubic), shrinkTowards = Alignment.Top) + fadeOut(tween(200)),
                 ) {
-                    Column {
+                    Column(
+                        modifier =
+                            Modifier.background(
+                                if (isAtTop) Color.Transparent else BuyOrNotTheme.colors.gray0,
+                            ),
+                    ) {
                         Spacer(modifier = Modifier.height(10.dp))
                         FilterChipRow(
                             selectedCategories = uiState.selectedCategories,


### PR DESCRIPTION
## 🛠 Related issue
closed #99

어떤 변경사항이 있었나요?
- [x] 🐞 BugFix Something isn't working
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [ ] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (Junit, etc.)

## ✅ CheckPoint
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 컨벤션에 맞게 작성했습니다. (필수)
- [x] merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕) (필수)
- [x] Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다. (필수)
- [x] BugFix의 경우, 버그의 원인을 파악하였습니다. (선택)

## ✏️ Work Description

https://github.com/user-attachments/assets/18d2d3b1-de5b-4546-a2c8-d404b199bd70

- `LazyColumn`이 내부 콘텐츠의 shadow를 clip하는 특성으로 인해 `HomeBanner`의 그림자가 잘리는 문제 수정
- `HomeFeedList`를 `Box` 오버레이 레이아웃으로 전환하여 shadow clipping 우회
  - `LazyColumn`을 `Box`의 첫 번째 자식으로 배치해 헤더 아래에 렌더링
  - 헤더를 오버레이로 올려 `LazyColumn`의 `contentPadding` 상단 영역에서 shadow 가시화
  - 최상단에서만 `FilterChipRow` 배경을 투명 처리해 배너 shadow 투과

## 😅 Uncompleted Tasks
- N/A

## 📢 To Reviewers
`LazyColumn`은 자체적으로 shadow를 clip하기 때문에 `clipToPadding` / `clipChildren` 등 단순 속성 변경으로는 해결이 불가능합니다. `Box` 오버레이로 헤더를 분리해 shadow가 헤더 영역까지 노출될 수 있도록 레이아웃 구조를 변경했습니다.

## 📃 RCA 룰
- R: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
- C: 웬만하면 반영해 주세요. (Comment)
- A: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 홈 피드 헤더가 플로팅 형식으로 개선되어 스크롤 시 목록 위에 떠있습니다.
  * 목록 최상단일 때 헤더 배경이 투명하게 변하는 스크롤 상태 감지 기능이 추가되었습니다.

* **스타일**
  * 배너 그림자 효과가 더 부드럽게 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->