### PR TITLE
Feat/#103 디자인 QA

### DIFF
--- a/core/data/src/main/java/com/sseotdabwa/buyornot/core/data/di/DataModule.kt
+++ b/core/data/src/main/java/com/sseotdabwa/buyornot/core/data/di/DataModule.kt
@@ -3,7 +3,7 @@ package com.sseotdabwa.buyornot.core.data.di
 import com.sseotdabwa.buyornot.core.data.repository.AppPreferencesRepositoryImpl
 import com.sseotdabwa.buyornot.core.data.repository.AppUpdateRepositoryImpl
 import com.sseotdabwa.buyornot.core.data.repository.AuthRepositoryImpl
-import com.sseotdabwa.buyornot.core.data.repository.FeedRepositoryImpl
+import com.sseotdabwa.buyornot.core.data.repository.FakeFeedRepository
 import com.sseotdabwa.buyornot.core.data.repository.NotificationRepositoryImpl
 import com.sseotdabwa.buyornot.core.data.repository.UserPreferencesRepositoryImpl
 import com.sseotdabwa.buyornot.core.data.repository.UserRepositoryImpl
@@ -29,7 +29,7 @@ internal abstract class DataModule {
     abstract fun bindUserRepository(impl: UserRepositoryImpl): UserRepository
 
     @Binds
-    abstract fun bindFeedRepository(impl: FeedRepositoryImpl): FeedRepository
+    abstract fun bindFeedRepository(impl: FakeFeedRepository): FeedRepository
 
     @Binds
     abstract fun bindNotificationRepository(impl: NotificationRepositoryImpl): NotificationRepository

--- a/core/data/src/main/java/com/sseotdabwa/buyornot/core/data/di/DataModule.kt
+++ b/core/data/src/main/java/com/sseotdabwa/buyornot/core/data/di/DataModule.kt
@@ -3,7 +3,7 @@ package com.sseotdabwa.buyornot.core.data.di
 import com.sseotdabwa.buyornot.core.data.repository.AppPreferencesRepositoryImpl
 import com.sseotdabwa.buyornot.core.data.repository.AppUpdateRepositoryImpl
 import com.sseotdabwa.buyornot.core.data.repository.AuthRepositoryImpl
-import com.sseotdabwa.buyornot.core.data.repository.FakeFeedRepository
+import com.sseotdabwa.buyornot.core.data.repository.FeedRepositoryImpl
 import com.sseotdabwa.buyornot.core.data.repository.NotificationRepositoryImpl
 import com.sseotdabwa.buyornot.core.data.repository.UserPreferencesRepositoryImpl
 import com.sseotdabwa.buyornot.core.data.repository.UserRepositoryImpl
@@ -29,7 +29,7 @@ internal abstract class DataModule {
     abstract fun bindUserRepository(impl: UserRepositoryImpl): UserRepository
 
     @Binds
-    abstract fun bindFeedRepository(impl: FakeFeedRepository): FeedRepository
+    abstract fun bindFeedRepository(impl: FeedRepositoryImpl): FeedRepository
 
     @Binds
     abstract fun bindNotificationRepository(impl: NotificationRepositoryImpl): NotificationRepository

--- a/core/designsystem/src/main/java/com/sseotdabwa/buyornot/core/designsystem/components/ActionPopup.kt
+++ b/core/designsystem/src/main/java/com/sseotdabwa/buyornot/core/designsystem/components/ActionPopup.kt
@@ -132,7 +132,11 @@ fun ActionPopupContent(
     ) {
         val pressedColor = BuyOrNotTheme.colors.gray200
         Column(
-            modifier = Modifier.padding(6.dp),
+            modifier =
+                Modifier.padding(
+                    horizontal = 6.dp,
+                    vertical = 10.dp,
+                ),
             verticalArrangement = Arrangement.spacedBy(4.dp),
         ) {
             items.forEach { (label, onClick) ->

--- a/core/designsystem/src/main/java/com/sseotdabwa/buyornot/core/designsystem/components/ActionSheet.kt
+++ b/core/designsystem/src/main/java/com/sseotdabwa/buyornot/core/designsystem/components/ActionSheet.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -64,7 +63,11 @@ fun ActionSheet(
         LazyColumn(
             modifier = Modifier.fillMaxWidth(),
             verticalArrangement = Arrangement.spacedBy(18.dp),
-            contentPadding = PaddingValues(vertical = 16.dp),
+            contentPadding =
+                PaddingValues(
+                    top = 26.dp,
+                    bottom = 30.dp,
+                ),
         ) {
             items(
                 count = actions.size,
@@ -92,9 +95,11 @@ private fun ActionItemRow(
         modifier =
             Modifier
                 .fillMaxWidth()
-                .height(30.dp)
                 .clickable(onClick = onClick)
-                .padding(horizontal = 24.dp),
+                .padding(
+                    horizontal = 24.dp,
+                    vertical = 6.dp,
+                ),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.Start,
     ) {

--- a/core/designsystem/src/main/java/com/sseotdabwa/buyornot/core/designsystem/components/FeedCard.kt
+++ b/core/designsystem/src/main/java/com/sseotdabwa/buyornot/core/designsystem/components/FeedCard.kt
@@ -86,6 +86,7 @@ fun FeedCard(
     productLink: String? = null,
     onLinkClick: (url: String) -> Unit = {},
     showProductLinkTooltip: Boolean = false,
+    onTooltipDismiss: () -> Unit = {},
     onImageClick: (imageUrls: List<String>, page: Int) -> Unit = { _, _ -> },
 ) {
     val hasVoted = userVotedOptionIndex != null
@@ -140,7 +141,10 @@ fun FeedCard(
                 price = price,
                 productLink = productLink,
                 showTooltip = tooltipVisible,
-                onTooltipDismiss = { tooltipVisible = false },
+                onTooltipDismiss = {
+                    tooltipVisible = false
+                    onTooltipDismiss()
+                },
                 onFullscreenClick = { page -> onImageClick(productImageUrls, page) },
                 onLinkClick = onLinkClick,
             )

--- a/feature/home/src/main/java/com/sseotdabwa/buyornot/feature/home/ui/HomeContract.kt
+++ b/feature/home/src/main/java/com/sseotdabwa/buyornot/feature/home/ui/HomeContract.kt
@@ -83,6 +83,7 @@ data class HomeUiState(
     val blockingNickname: String? = null,
     val blockingUserId: Long? = null,
     val showSortSheet: Boolean = false,
+    val isTooltipDismissed: Boolean = false,
 )
 
 /**
@@ -141,6 +142,8 @@ sealed interface HomeIntent {
     data object ShowSortSheet : HomeIntent
 
     data object DismissSortSheet : HomeIntent
+
+    data object DismissTooltip : HomeIntent
 }
 
 /**

--- a/feature/home/src/main/java/com/sseotdabwa/buyornot/feature/home/ui/HomeScreen.kt
+++ b/feature/home/src/main/java/com/sseotdabwa/buyornot/feature/home/ui/HomeScreen.kt
@@ -507,14 +507,14 @@ private fun HomeFeedList(
                         item {
                             if (uiState.selectedTab == HomeTab.MY_FEED) {
                                 HomeFeedEmptyView(
-                                    modifier = Modifier.padding(top = 140.dp),
+                                    modifier = Modifier.padding(top = 120.dp),
                                     title = "아직 올린 투표가 없어요",
                                     description = "고민되는 상품의 투표를 올려보세요!",
                                     onUploadClick = onUploadClick,
                                 )
                             } else {
                                 HomeFeedEmptyView(
-                                    modifier = Modifier.padding(top = 120.dp),
+                                    modifier = Modifier.padding(top = 100.dp),
                                     title = "첫번째 투표를 올려보세요!",
                                     onUploadClick = onUploadClick,
                                 )

--- a/feature/home/src/main/java/com/sseotdabwa/buyornot/feature/home/ui/HomeScreen.kt
+++ b/feature/home/src/main/java/com/sseotdabwa/buyornot/feature/home/ui/HomeScreen.kt
@@ -569,7 +569,6 @@ private fun HomeFeedList(
                             selectedCategories = uiState.selectedCategories,
                             onAllCategorySelected = { onIntent(HomeIntent.OnAllCategorySelected) },
                             onCategoryToggled = { onIntent(HomeIntent.OnCategoryToggled(it)) },
-                            selectedFilter = uiState.selectedFilter,
                             onShowSortSheet = { onIntent(HomeIntent.ShowSortSheet) },
                         )
                         Spacer(modifier = Modifier.height(10.dp))
@@ -604,7 +603,6 @@ private fun FilterChipRow(
     selectedCategories: Set<FeedCategory>,
     onAllCategorySelected: () -> Unit,
     onCategoryToggled: (FeedCategory) -> Unit,
-    selectedFilter: FilterChip,
     onShowSortSheet: () -> Unit,
 ) {
     val listState = rememberLazyListState()

--- a/feature/home/src/main/java/com/sseotdabwa/buyornot/feature/home/ui/HomeScreen.kt
+++ b/feature/home/src/main/java/com/sseotdabwa/buyornot/feature/home/ui/HomeScreen.kt
@@ -674,8 +674,12 @@ private fun FilterChipRow(
                             )
                         }
                     },
-            contentPadding = PaddingValues(horizontal = 8.dp),
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            contentPadding =
+                PaddingValues(
+                    start = 6.dp,
+                    end = 20.dp,
+                ),
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             item {

--- a/feature/home/src/main/java/com/sseotdabwa/buyornot/feature/home/ui/HomeScreen.kt
+++ b/feature/home/src/main/java/com/sseotdabwa/buyornot/feature/home/ui/HomeScreen.kt
@@ -369,7 +369,6 @@ private fun HomeFeedList(
         derivedStateOf { listState.firstVisibleItemIndex == 0 && listState.firstVisibleItemScrollOffset == 0 }
     }
 
-    var showLinkTooltip by remember { mutableStateOf(true) }
     val tooltipTargetIndex =
         remember(filteredFeeds) {
             filteredFeeds.indexOfFirst { it.productLink != null }
@@ -454,12 +453,13 @@ private fun HomeFeedList(
                                 voterProfileImageUrl = uiState.voterProfileImageUrl,
                                 isGuest = uiState.userType == UserType.GUEST,
                                 modifier = Modifier.animateItem(),
-                                showProductLinkTooltip = showLinkTooltip && index == tooltipTargetIndex,
+                                showProductLinkTooltip = !uiState.isTooltipDismissed && index == tooltipTargetIndex,
                                 onVote = { id, opt -> onIntent(HomeIntent.OnVoteClicked(id, opt)) },
                                 onDelete = { id -> onIntent(HomeIntent.ShowDeleteDialog(id)) },
                                 onReport = { id -> onIntent(HomeIntent.OnReportClicked(id)) },
                                 onBlock = { id -> onIntent(HomeIntent.ShowBlockDialog(id)) },
                                 onLinkClick = onLinkClick,
+                                onTooltipDismissed = { onIntent(HomeIntent.DismissTooltip) },
                                 onImageClick = onImageClick,
                             )
                         }
@@ -726,6 +726,7 @@ private fun FeedItemCard(
     onReport: (String) -> Unit,
     onBlock: (String) -> Unit,
     onLinkClick: (url: String) -> Unit,
+    onTooltipDismissed: () -> Unit = {},
     onImageClick: (imageUrls: List<String>, page: Int) -> Unit = { _, _ -> },
 ) {
     Column {
@@ -757,6 +758,7 @@ private fun FeedItemCard(
             productLink = feed.productLink,
             onLinkClick = onLinkClick,
             showProductLinkTooltip = showProductLinkTooltip,
+            onTooltipDismiss = onTooltipDismissed,
             onImageClick = onImageClick,
         )
 

--- a/feature/home/src/main/java/com/sseotdabwa/buyornot/feature/home/ui/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/sseotdabwa/buyornot/feature/home/ui/HomeViewModel.kt
@@ -132,6 +132,7 @@ class HomeViewModel @Inject constructor(
             }
             is HomeIntent.ShowSortSheet -> updateState { it.copy(showSortSheet = true) }
             is HomeIntent.DismissSortSheet -> updateState { it.copy(showSortSheet = false) }
+            is HomeIntent.DismissTooltip -> updateState { it.copy(isTooltipDismissed = true) }
         }
     }
 

--- a/feature/notification/src/main/java/com/sseotdabwa/buyornot/feature/notification/ui/NotificationScreen.kt
+++ b/feature/notification/src/main/java/com/sseotdabwa/buyornot/feature/notification/ui/NotificationScreen.kt
@@ -286,7 +286,7 @@ private fun NotificationFilterRow(
     LazyRow(
         modifier = Modifier.fillMaxWidth(),
         contentPadding = PaddingValues(horizontal = 20.dp),
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        horizontalArrangement = Arrangement.spacedBy(6.dp),
     ) {
         items(filters) { filter ->
             val filterText =

--- a/feature/upload/src/main/java/com/sseotdabwa/buyornot/feature/upload/ui/UploadScreen.kt
+++ b/feature/upload/src/main/java/com/sseotdabwa/buyornot/feature/upload/ui/UploadScreen.kt
@@ -11,6 +11,7 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -706,7 +707,12 @@ private fun SelectedImagePreview(
         modifier =
             Modifier
                 .size(68.dp)
-                .clip(RoundedCornerShape(12.dp)),
+                .clip(RoundedCornerShape(12.dp))
+                .border(
+                    width = 1.dp,
+                    color = BuyOrNotTheme.colors.gray300,
+                    shape = RoundedCornerShape(12.dp),
+                ),
         contentAlignment = Alignment.TopEnd,
     ) {
         AsyncImage(


### PR DESCRIPTION
## 🛠 Related issue
closed #103

어떤 변경사항이 있었나요?
- [x] 🐞 BugFix Something isn't working
- [x] 🎨 Design Markup & styling

## ✅ CheckPoint
- [x] PR 컨벤션에 맞게 작성했습니다. (필수)
- [x] merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕) (필수)
- [x] Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다. (필수)
- [x] BugFix의 경우, 버그의 원인을 파악하였습니다. (선택)

## ✏️ Work Description
- 홈 화면 카테고리 리스트 패딩 및 간격 조정
- 홈 화면 EmptyView 상단 간격 조정
- ActionSheet 디자인 수정 (contentPadding 및 아이템 고정 높이 제거 → vertical padding으로 교체)
- ActionPopup 내부 여백 조정 (vertical padding 추가)
- NotificationScreen 필터 간격 수정 (8dp → 6dp)
- 업로드 화면 사진 선택 시 stroke 추가
- HomeHeader에서 미사용 `selectedFilter` 파라미터 제거
- 링크 툴팁 dismiss 상태를 ViewModel로 이관하여 세션 내 재노출 버그 수정
  - 버그 원인: `FeedCard` 내 `remember(showProductLinkTooltip)` 키가 `true`인 채로 유지되어 LazyColumn 스크롤 후 재진입 시 툴팁 재초기화
  - 수정: dismiss 시 `HomeIntent.DismissTooltip` 전달 → ViewModel `isTooltipDismissed = true` 유지 (앱 재시작 시 초기화)

## 😅 Uncompleted Tasks
N/A

## 📢 To Reviewers
- 툴팁 버그 수정은 `HomeContract`, `HomeViewModel`, `HomeScreen`, `FeedCard` 4개 파일에 걸쳐 있습니다.
- 세션(앱 프로세스 생존 기간) 동안 dismiss 상태가 유지되며, 앱 재시작 시 ViewModel 재생성으로 자동 초기화됩니다.

## 📃 RCA 룰
- R: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
- C: 웬만하면 반영해 주세요. (Comment)
- A: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 제품 링크 툴팁 해제 기능 추가

* **스타일**
  * 액션 팝업 및 액션 시트 레이아웃 패딩 조정
  * 피드 필터 칩 간격 6dp로 통일
  * 알림 화면 필터 행 간격 조정
  * 업로드 화면 이미지 미리보기에 테두리 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->