### PR TITLE
feat/#105: Mixpanel 기반 이벤트 로깅 연동 (피드/투표 생성 흐름)

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -38,6 +38,7 @@ jobs:
           echo "google.webClientId=${{ secrets.GOOGLE_WEB_CLIENT_ID }}" >> local.properties
           echo "kakao.nativeAppKey=${{ secrets.KAKAO_NATIVE_APP_KEY }}" >> local.properties
           echo "kakao.nativeAppKeyDebug=${{ secrets.KAKAO_NATIVE_APP_KEY_DEBUG }}" >> local.properties
+          echo "mixpanel.token=${{ secrets.MIXPANEL_TOKEN }}" >> local.properties
 
       - name: Decode Keystore
         run: echo "${{ secrets.KEYSTORE_BASE64 }}" | base64 --decode > app/keystore.jks

--- a/.github/workflows/distribute.yml
+++ b/.github/workflows/distribute.yml
@@ -56,6 +56,7 @@ jobs:
           echo "google.webClientId=${{ secrets.GOOGLE_WEB_CLIENT_ID }}" >> local.properties
           echo "kakao.nativeAppKey=${{ secrets.KAKAO_NATIVE_APP_KEY }}" >> local.properties
           echo "kakao.nativeAppKeyDebug=${{ secrets.KAKAO_NATIVE_APP_KEY_DEBUG }}" >> local.properties
+          echo "mixpanel.token=${{ secrets.MIXPANEL_TOKEN }}" >> local.properties
 
       - name: Decode Keystore
         run: echo "${{ secrets.KEYSTORE_BASE64 }}" | base64 --decode > app/keystore.jks

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -101,6 +101,7 @@ android {
 
 dependencies {
     implementation(projects.domain)
+    implementation(projects.core.analytics)
     implementation(projects.core.data)
     implementation(projects.core.network)
     implementation(projects.core.datastore)

--- a/core/analytics/build.gradle.kts
+++ b/core/analytics/build.gradle.kts
@@ -1,0 +1,43 @@
+import java.util.Properties
+
+plugins {
+    id("buyornot.android.library")
+    alias(libs.plugins.hilt)
+    alias(libs.plugins.ksp)
+}
+
+val localProperties =
+    Properties().apply {
+        val localPropertiesFile = rootProject.file("local.properties")
+        if (localPropertiesFile.exists()) {
+            localPropertiesFile.inputStream().use { load(it) }
+        }
+    }
+
+android {
+    namespace = "com.sseotdabwa.buyornot.core.analytics"
+
+    buildFeatures {
+        buildConfig = true
+    }
+
+    buildTypes {
+        debug {
+            buildConfigField("String", "MIXPANEL_TOKEN", "\"\"")
+        }
+        release {
+            buildConfigField(
+                "String",
+                "MIXPANEL_TOKEN",
+                "\"${localProperties.getProperty("mixpanel.token", "")}\"",
+            )
+        }
+    }
+}
+
+dependencies {
+    implementation(libs.mixpanel.android)
+
+    implementation(libs.hilt.android)
+    ksp(libs.hilt.compiler)
+}

--- a/core/analytics/src/main/java/com/sseotdabwa/buyornot/core/analytics/Analytics.kt
+++ b/core/analytics/src/main/java/com/sseotdabwa/buyornot/core/analytics/Analytics.kt
@@ -1,0 +1,5 @@
+package com.sseotdabwa.buyornot.core.analytics
+
+interface Analytics {
+    fun track(event: AnalyticsEvent)
+}

--- a/core/analytics/src/main/java/com/sseotdabwa/buyornot/core/analytics/AnalyticsEvent.kt
+++ b/core/analytics/src/main/java/com/sseotdabwa/buyornot/core/analytics/AnalyticsEvent.kt
@@ -17,6 +17,7 @@ sealed class AnalyticsEvent {
     ) : AnalyticsEvent()
 
     data class VoteCreateStarted(
+        val entrySource: String,
         val isLoggedIn: Boolean,
     ) : AnalyticsEvent()
 

--- a/core/analytics/src/main/java/com/sseotdabwa/buyornot/core/analytics/AnalyticsEvent.kt
+++ b/core/analytics/src/main/java/com/sseotdabwa/buyornot/core/analytics/AnalyticsEvent.kt
@@ -2,7 +2,6 @@ package com.sseotdabwa.buyornot.core.analytics
 
 sealed class AnalyticsEvent {
     data class FeedViewed(
-        val entrySource: String,
         val firstVisibleItemIndex: Int,
     ) : AnalyticsEvent()
 
@@ -18,7 +17,6 @@ sealed class AnalyticsEvent {
     ) : AnalyticsEvent()
 
     data class VoteCreateStarted(
-        val entrySource: String,
         val isLoggedIn: Boolean,
     ) : AnalyticsEvent()
 

--- a/core/analytics/src/main/java/com/sseotdabwa/buyornot/core/analytics/AnalyticsEvent.kt
+++ b/core/analytics/src/main/java/com/sseotdabwa/buyornot/core/analytics/AnalyticsEvent.kt
@@ -1,0 +1,35 @@
+package com.sseotdabwa.buyornot.core.analytics
+
+sealed class AnalyticsEvent {
+    data class FeedViewed(
+        val entrySource: String,
+        val firstVisibleItemIndex: Int,
+    ) : AnalyticsEvent()
+
+    data class FeedExited(
+        val timeSpentSeconds: Float,
+        val lastVisibleItemIndex: Int,
+    ) : AnalyticsEvent()
+
+    data class VoteSubmitted(
+        val feedId: Long,
+        val voteChoice: String,
+        val feedCategory: String,
+    ) : AnalyticsEvent()
+
+    data class VoteCreateStarted(
+        val entrySource: String,
+        val isLoggedIn: Boolean,
+    ) : AnalyticsEvent()
+
+    data class VoteCreateCompleted(
+        val itemId: Long,
+        val voteTitle: String,
+        val optionCount: Int,
+    ) : AnalyticsEvent()
+
+    data class VoteCreateAbandoned(
+        val filledFields: List<String>,
+        val lastStep: String?,
+    ) : AnalyticsEvent()
+}

--- a/core/analytics/src/main/java/com/sseotdabwa/buyornot/core/analytics/DebugAnalytics.kt
+++ b/core/analytics/src/main/java/com/sseotdabwa/buyornot/core/analytics/DebugAnalytics.kt
@@ -1,0 +1,9 @@
+package com.sseotdabwa.buyornot.core.analytics
+
+import android.util.Log
+
+class DebugAnalytics : Analytics {
+    override fun track(event: AnalyticsEvent) {
+        Log.d("Analytics", event.toString())
+    }
+}

--- a/core/analytics/src/main/java/com/sseotdabwa/buyornot/core/analytics/MixpanelAnalytics.kt
+++ b/core/analytics/src/main/java/com/sseotdabwa/buyornot/core/analytics/MixpanelAnalytics.kt
@@ -17,7 +17,6 @@ class MixpanelAnalytics(
         val name =
             when (this) {
                 is AnalyticsEvent.FeedViewed -> {
-                    props.put("entry_source", entrySource)
                     props.put("first_visible_item_index", firstVisibleItemIndex)
                     "feed_viewed"
                 }
@@ -33,7 +32,6 @@ class MixpanelAnalytics(
                     "vote_submitted"
                 }
                 is AnalyticsEvent.VoteCreateStarted -> {
-                    props.put("entry_source", entrySource)
                     props.put("is_logged_in", isLoggedIn)
                     "vote_create_started"
                 }

--- a/core/analytics/src/main/java/com/sseotdabwa/buyornot/core/analytics/MixpanelAnalytics.kt
+++ b/core/analytics/src/main/java/com/sseotdabwa/buyornot/core/analytics/MixpanelAnalytics.kt
@@ -1,0 +1,54 @@
+package com.sseotdabwa.buyornot.core.analytics
+
+import com.mixpanel.android.mpmetrics.MixpanelAPI
+import org.json.JSONArray
+import org.json.JSONObject
+
+class MixpanelAnalytics(
+    private val mixpanel: MixpanelAPI,
+) : Analytics {
+    override fun track(event: AnalyticsEvent) {
+        val (name, props) = event.toMixpanel()
+        mixpanel.track(name, props)
+    }
+
+    private fun AnalyticsEvent.toMixpanel(): Pair<String, JSONObject> {
+        val props = JSONObject()
+        val name =
+            when (this) {
+                is AnalyticsEvent.FeedViewed -> {
+                    props.put("entry_source", entrySource)
+                    props.put("first_visible_item_index", firstVisibleItemIndex)
+                    "feed_viewed"
+                }
+                is AnalyticsEvent.FeedExited -> {
+                    props.put("time_spent_seconds", timeSpentSeconds)
+                    props.put("last_visible_item_index", lastVisibleItemIndex)
+                    "feed_exited"
+                }
+                is AnalyticsEvent.VoteSubmitted -> {
+                    props.put("feed_id", feedId)
+                    props.put("vote_choice", voteChoice)
+                    props.put("feed_category", feedCategory)
+                    "vote_submitted"
+                }
+                is AnalyticsEvent.VoteCreateStarted -> {
+                    props.put("entry_source", entrySource)
+                    props.put("is_logged_in", isLoggedIn)
+                    "vote_create_started"
+                }
+                is AnalyticsEvent.VoteCreateCompleted -> {
+                    props.put("item_id", itemId)
+                    props.put("vote_title", voteTitle)
+                    props.put("option_count", optionCount)
+                    "vote_create_completed"
+                }
+                is AnalyticsEvent.VoteCreateAbandoned -> {
+                    props.put("filled_fields", JSONArray(filledFields))
+                    if (lastStep != null) props.put("last_step", lastStep)
+                    "vote_create_abandoned"
+                }
+            }
+        return name to props
+    }
+}

--- a/core/analytics/src/main/java/com/sseotdabwa/buyornot/core/analytics/MixpanelAnalytics.kt
+++ b/core/analytics/src/main/java/com/sseotdabwa/buyornot/core/analytics/MixpanelAnalytics.kt
@@ -32,6 +32,7 @@ class MixpanelAnalytics(
                     "vote_submitted"
                 }
                 is AnalyticsEvent.VoteCreateStarted -> {
+                    props.put("entry_source", entrySource)
                     props.put("is_logged_in", isLoggedIn)
                     "vote_create_started"
                 }

--- a/core/analytics/src/main/java/com/sseotdabwa/buyornot/core/analytics/di/AnalyticsModule.kt
+++ b/core/analytics/src/main/java/com/sseotdabwa/buyornot/core/analytics/di/AnalyticsModule.kt
@@ -1,0 +1,35 @@
+package com.sseotdabwa.buyornot.core.analytics.di
+
+import android.content.Context
+import com.mixpanel.android.mpmetrics.MixpanelAPI
+import com.sseotdabwa.buyornot.core.analytics.Analytics
+import com.sseotdabwa.buyornot.core.analytics.BuildConfig
+import com.sseotdabwa.buyornot.core.analytics.DebugAnalytics
+import com.sseotdabwa.buyornot.core.analytics.MixpanelAnalytics
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object AnalyticsModule {
+    @Provides
+    @Singleton
+    fun provideAnalytics(
+        @ApplicationContext context: Context,
+    ): Analytics =
+        if (BuildConfig.DEBUG) {
+            DebugAnalytics()
+        } else {
+            val mixpanel =
+                MixpanelAPI.getInstance(
+                    context,
+                    BuildConfig.MIXPANEL_TOKEN,
+                    true,
+                )
+            MixpanelAnalytics(mixpanel)
+        }
+}

--- a/feature/home/build.gradle.kts
+++ b/feature/home/build.gradle.kts
@@ -7,6 +7,7 @@ android {
 }
 
 dependencies {
+    implementation(projects.core.analytics)
     implementation(projects.domain)
     implementation(projects.core.common)
     implementation(projects.core.designsystem)

--- a/feature/home/src/main/java/com/sseotdabwa/buyornot/feature/home/ui/HomeContract.kt
+++ b/feature/home/src/main/java/com/sseotdabwa/buyornot/feature/home/ui/HomeContract.kt
@@ -144,6 +144,15 @@ sealed interface HomeIntent {
     data object DismissSortSheet : HomeIntent
 
     data object DismissTooltip : HomeIntent
+
+    data class OnFeedScreenEntered(
+        val firstVisibleItemIndex: Int,
+    ) : HomeIntent
+
+    data class OnFeedScreenExited(
+        val lastVisibleItemIndex: Int,
+        val timeSpentSeconds: Float,
+    ) : HomeIntent
 }
 
 /**

--- a/feature/home/src/main/java/com/sseotdabwa/buyornot/feature/home/ui/HomeScreen.kt
+++ b/feature/home/src/main/java/com/sseotdabwa/buyornot/feature/home/ui/HomeScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
@@ -363,6 +364,19 @@ private fun HomeFeedList(
     val listState = rememberLazyListState()
     val isEmptyViewVisible = filteredFeeds.isEmpty() && !uiState.isLoading && !uiState.hasError
     val isMyFeedEmpty = uiState.selectedTab == HomeTab.MY_FEED && isEmptyViewVisible
+
+    val enterTimeMs = remember { System.currentTimeMillis() }
+    DisposableEffect(Unit) {
+        onIntent(HomeIntent.OnFeedScreenEntered(firstVisibleItemIndex = listState.firstVisibleItemIndex))
+        onDispose {
+            onIntent(
+                HomeIntent.OnFeedScreenExited(
+                    lastVisibleItemIndex = listState.firstVisibleItemIndex,
+                    timeSpentSeconds = (System.currentTimeMillis() - enterTimeMs) / 1000f,
+                ),
+            )
+        }
+    }
     var headerHeightPx by remember { mutableIntStateOf(0) }
     val density = LocalDensity.current
     val isAtTop by remember {

--- a/feature/home/src/main/java/com/sseotdabwa/buyornot/feature/home/ui/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/sseotdabwa/buyornot/feature/home/ui/HomeViewModel.kt
@@ -284,17 +284,6 @@ class HomeViewModel @Inject constructor(
                     UserType.GUEST -> feedRepository.voteGuestFeed(feedId.toLong(), choice)
                 }
             }.onSuccess { voteResult ->
-                analytics.track(
-                    AnalyticsEvent.VoteSubmitted(
-                        feedId = targetFeed.id.toLong(),
-                        voteChoice = if (optionIndex == 0) "YES" else "NO",
-                        feedCategory =
-                            FeedCategory.entries
-                                .find { it.displayName == targetFeed.category }
-                                ?.name
-                                ?: targetFeed.category,
-                    ),
-                )
                 // 2. 최종 업데이트: 서버 응답으로 확정
                 updateState { state ->
                     val newAllFeeds =
@@ -315,6 +304,17 @@ class HomeViewModel @Inject constructor(
                         feeds = applyCategories(newAllFeeds, state.selectedCategories),
                     )
                 }
+                analytics.track(
+                    AnalyticsEvent.VoteSubmitted(
+                        feedId = targetFeed.id.toLong(),
+                        voteChoice = if (optionIndex == 0) "YES" else "NO",
+                        feedCategory =
+                            FeedCategory.entries
+                                .find { it.displayName == targetFeed.category }
+                                ?.name
+                                ?: targetFeed.category,
+                    ),
+                )
             }.onFailure { e ->
                 Log.e("HomeViewModel", "Failed to vote feed: $feedId", e)
                 // 3. 롤백 (Rollback): 해당 피드만 원복, 나머지 동시 변경사항 보존

--- a/feature/home/src/main/java/com/sseotdabwa/buyornot/feature/home/ui/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/sseotdabwa/buyornot/feature/home/ui/HomeViewModel.kt
@@ -2,6 +2,8 @@ package com.sseotdabwa.buyornot.feature.home.ui
 
 import android.util.Log
 import androidx.lifecycle.viewModelScope
+import com.sseotdabwa.buyornot.core.analytics.Analytics
+import com.sseotdabwa.buyornot.core.analytics.AnalyticsEvent
 import com.sseotdabwa.buyornot.core.common.util.TimeUtils
 import com.sseotdabwa.buyornot.core.common.util.runCatchingCancellable
 import com.sseotdabwa.buyornot.core.designsystem.components.ImageAspectRatio
@@ -28,6 +30,7 @@ class HomeViewModel @Inject constructor(
     private val userPreferencesRepository: UserPreferencesRepository,
     private val feedRepository: FeedRepository,
     private val userRepository: UserRepository,
+    private val analytics: Analytics,
 ) : BaseViewModel<HomeUiState, HomeIntent, HomeSideEffect>(HomeUiState()) {
     private var currentUserId: Long? = null
     private var isUserIdLoaded = false
@@ -133,6 +136,20 @@ class HomeViewModel @Inject constructor(
             is HomeIntent.ShowSortSheet -> updateState { it.copy(showSortSheet = true) }
             is HomeIntent.DismissSortSheet -> updateState { it.copy(showSortSheet = false) }
             is HomeIntent.DismissTooltip -> updateState { it.copy(isTooltipDismissed = true) }
+            is HomeIntent.OnFeedScreenEntered ->
+                analytics.track(
+                    AnalyticsEvent.FeedViewed(
+                        entrySource = "home",
+                        firstVisibleItemIndex = intent.firstVisibleItemIndex,
+                    ),
+                )
+            is HomeIntent.OnFeedScreenExited ->
+                analytics.track(
+                    AnalyticsEvent.FeedExited(
+                        timeSpentSeconds = intent.timeSpentSeconds,
+                        lastVisibleItemIndex = intent.lastVisibleItemIndex,
+                    ),
+                )
         }
     }
 
@@ -249,6 +266,18 @@ class HomeViewModel @Inject constructor(
             targetFeed.isOwner || targetFeed.isVoteEnded -> return
             targetFeed.userVotedOptionIndex != null -> return
         }
+
+        analytics.track(
+            AnalyticsEvent.VoteSubmitted(
+                feedId = targetFeed.id.toLong(),
+                voteChoice = if (optionIndex == 0) "YES" else "NO",
+                feedCategory =
+                    FeedCategory.entries
+                        .find { it.displayName == targetFeed.category }
+                        ?.name
+                        ?: targetFeed.category,
+            ),
+        )
 
         // 1. 낙관적 업데이트 (Optimistic Update)
         updateState { state ->

--- a/feature/home/src/main/java/com/sseotdabwa/buyornot/feature/home/ui/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/sseotdabwa/buyornot/feature/home/ui/HomeViewModel.kt
@@ -266,18 +266,6 @@ class HomeViewModel @Inject constructor(
             targetFeed.userVotedOptionIndex != null -> return
         }
 
-        analytics.track(
-            AnalyticsEvent.VoteSubmitted(
-                feedId = targetFeed.id.toLong(),
-                voteChoice = if (optionIndex == 0) "YES" else "NO",
-                feedCategory =
-                    FeedCategory.entries
-                        .find { it.displayName == targetFeed.category }
-                        ?.name
-                        ?: targetFeed.category,
-            ),
-        )
-
         // 1. 낙관적 업데이트 (Optimistic Update)
         updateState { state ->
             val newAllFeeds = optimisticVoteUpdate(state.allFeeds, feedId, optionIndex)
@@ -296,6 +284,17 @@ class HomeViewModel @Inject constructor(
                     UserType.GUEST -> feedRepository.voteGuestFeed(feedId.toLong(), choice)
                 }
             }.onSuccess { voteResult ->
+                analytics.track(
+                    AnalyticsEvent.VoteSubmitted(
+                        feedId = targetFeed.id.toLong(),
+                        voteChoice = if (optionIndex == 0) "YES" else "NO",
+                        feedCategory =
+                            FeedCategory.entries
+                                .find { it.displayName == targetFeed.category }
+                                ?.name
+                                ?: targetFeed.category,
+                    ),
+                )
                 // 2. 최종 업데이트: 서버 응답으로 확정
                 updateState { state ->
                     val newAllFeeds =

--- a/feature/home/src/main/java/com/sseotdabwa/buyornot/feature/home/ui/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/sseotdabwa/buyornot/feature/home/ui/HomeViewModel.kt
@@ -139,7 +139,6 @@ class HomeViewModel @Inject constructor(
             is HomeIntent.OnFeedScreenEntered ->
                 analytics.track(
                     AnalyticsEvent.FeedViewed(
-                        entrySource = "home",
                         firstVisibleItemIndex = intent.firstVisibleItemIndex,
                     ),
                 )

--- a/feature/upload/build.gradle.kts
+++ b/feature/upload/build.gradle.kts
@@ -7,6 +7,7 @@ android {
 }
 
 dependencies {
+    implementation(projects.core.analytics)
     implementation(projects.core.common)
     implementation(projects.domain)
     implementation(projects.core.designsystem)

--- a/feature/upload/src/main/java/com/sseotdabwa/buyornot/feature/upload/ui/UploadContract.kt
+++ b/feature/upload/src/main/java/com/sseotdabwa/buyornot/feature/upload/ui/UploadContract.kt
@@ -18,6 +18,7 @@ data class UploadUiState(
     val showExitDialog: Boolean = false,
     val showPhotoPickerSheet: Boolean = false,
     val categories: List<FeedCategory> = FeedCategory.entries,
+    val lastTouchedField: String? = null,
 ) {
     val hasInput: Boolean
         get() =
@@ -27,6 +28,17 @@ data class UploadUiState(
                 link.isNotEmpty() ||
                 title.isNotEmpty() ||
                 content.isNotEmpty()
+
+    val filledFields: List<String>
+        get() =
+            buildList {
+                if (selectedImageUris.isNotEmpty()) add("images")
+                if (category != null) add("category")
+                if (price.isNotEmpty()) add("price")
+                if (link.isNotEmpty()) add("link")
+                if (title.isNotEmpty()) add("title")
+                if (content.isNotEmpty()) add("content")
+            }
 }
 
 sealed interface UploadIntent {

--- a/feature/upload/src/main/java/com/sseotdabwa/buyornot/feature/upload/ui/UploadViewModel.kt
+++ b/feature/upload/src/main/java/com/sseotdabwa/buyornot/feature/upload/ui/UploadViewModel.kt
@@ -30,6 +30,7 @@ class UploadViewModel @Inject constructor(
             val userType = userPreferencesRepository.userType.first()
             analytics.track(
                 AnalyticsEvent.VoteCreateStarted(
+                    entrySource = "home",
                     isLoggedIn = userType == UserType.SOCIAL,
                 ),
             )

--- a/feature/upload/src/main/java/com/sseotdabwa/buyornot/feature/upload/ui/UploadViewModel.kt
+++ b/feature/upload/src/main/java/com/sseotdabwa/buyornot/feature/upload/ui/UploadViewModel.kt
@@ -90,6 +90,10 @@ class UploadViewModel @Inject constructor(
                     it.copy(showPhotoPickerSheet = intent.isVisible)
                 }
             UploadIntent.NavigateBack -> {
+                updateState {
+                    it.copy(showExitDialog = false, showCategorySheet = false)
+                }
+                sendSideEffect(UploadSideEffect.NavigateBack)
                 if (currentState.hasInput) {
                     analytics.track(
                         AnalyticsEvent.VoteCreateAbandoned(
@@ -98,10 +102,6 @@ class UploadViewModel @Inject constructor(
                         ),
                     )
                 }
-                updateState {
-                    it.copy(showExitDialog = false, showCategorySheet = false)
-                }
-                sendSideEffect(UploadSideEffect.NavigateBack)
             }
         }
     }
@@ -161,6 +161,8 @@ class UploadViewModel @Inject constructor(
                     link = link,
                 )
             }.onSuccess { feedId ->
+                updateState { it.copy(isLoading = false) }
+                sendSideEffect(UploadSideEffect.NavigateToHomeReview)
                 analytics.track(
                     AnalyticsEvent.VoteCreateCompleted(
                         itemId = feedId,
@@ -168,8 +170,6 @@ class UploadViewModel @Inject constructor(
                         optionCount = currentState.selectedImageUris.size,
                     ),
                 )
-                updateState { it.copy(isLoading = false) }
-                sendSideEffect(UploadSideEffect.NavigateToHomeReview)
             }.onFailure { throwable ->
                 updateState { it.copy(isLoading = false) }
                 sendSideEffect(UploadSideEffect.ShowSnackbar("업로드에 실패했습니다."))

--- a/feature/upload/src/main/java/com/sseotdabwa/buyornot/feature/upload/ui/UploadViewModel.kt
+++ b/feature/upload/src/main/java/com/sseotdabwa/buyornot/feature/upload/ui/UploadViewModel.kt
@@ -30,7 +30,6 @@ class UploadViewModel @Inject constructor(
             val userType = userPreferencesRepository.userType.first()
             analytics.track(
                 AnalyticsEvent.VoteCreateStarted(
-                    entrySource = "home",
                     isLoggedIn = userType == UserType.SOCIAL,
                 ),
             )

--- a/feature/upload/src/main/java/com/sseotdabwa/buyornot/feature/upload/ui/UploadViewModel.kt
+++ b/feature/upload/src/main/java/com/sseotdabwa/buyornot/feature/upload/ui/UploadViewModel.kt
@@ -5,19 +5,38 @@ import android.graphics.BitmapFactory
 import android.net.Uri
 import android.provider.OpenableColumns
 import androidx.lifecycle.viewModelScope
+import com.sseotdabwa.buyornot.core.analytics.Analytics
+import com.sseotdabwa.buyornot.core.analytics.AnalyticsEvent
 import com.sseotdabwa.buyornot.core.common.util.runCatchingCancellable
 import com.sseotdabwa.buyornot.core.ui.base.BaseViewModel
 import com.sseotdabwa.buyornot.domain.model.FeedImage
+import com.sseotdabwa.buyornot.domain.model.UserType
 import com.sseotdabwa.buyornot.domain.repository.FeedRepository
+import com.sseotdabwa.buyornot.domain.repository.UserPreferencesRepository
 import com.sseotdabwa.buyornot.feature.upload.util.LinkValidator
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class UploadViewModel @Inject constructor(
     private val feedRepository: FeedRepository,
+    private val userPreferencesRepository: UserPreferencesRepository,
+    private val analytics: Analytics,
 ) : BaseViewModel<UploadUiState, UploadIntent, UploadSideEffect>(UploadUiState()) {
+    init {
+        viewModelScope.launch {
+            val userType = userPreferencesRepository.userType.first()
+            analytics.track(
+                AnalyticsEvent.VoteCreateStarted(
+                    entrySource = "home",
+                    isLoggedIn = userType == UserType.SOCIAL,
+                ),
+            )
+        }
+    }
+
     companion object {
         private const val MAX_IMAGE_COUNT = 3
         private const val MAX_TITLE_LENGTH = 40
@@ -28,29 +47,29 @@ class UploadViewModel @Inject constructor(
         when (intent) {
             is UploadIntent.UpdateCategory ->
                 updateState {
-                    it.copy(category = intent.category, showCategorySheet = false)
+                    it.copy(category = intent.category, showCategorySheet = false, lastTouchedField = "category")
                 }
             is UploadIntent.UpdatePrice ->
                 updateState {
-                    it.copy(price = intent.digits, priceFieldValue = intent.textFieldValue)
+                    it.copy(price = intent.digits, priceFieldValue = intent.textFieldValue, lastTouchedField = "price")
                 }
             is UploadIntent.UpdateLink ->
-                updateState { it.copy(link = intent.link) }
+                updateState { it.copy(link = intent.link, lastTouchedField = "link") }
             is UploadIntent.UpdateTitle -> {
                 if (intent.title.length <= MAX_TITLE_LENGTH) {
-                    updateState { it.copy(title = intent.title) }
+                    updateState { it.copy(title = intent.title, lastTouchedField = "title") }
                 }
             }
             is UploadIntent.UpdateContent -> {
                 if (intent.content.length <= MAX_CONTENT_LENGTH) {
-                    updateState { it.copy(content = intent.content) }
+                    updateState { it.copy(content = intent.content, lastTouchedField = "content") }
                 }
             }
             is UploadIntent.AddImages -> {
                 val remaining = MAX_IMAGE_COUNT - currentState.selectedImageUris.size
                 val toAdd = intent.uris.take(remaining)
                 val hasOverflow = toAdd.size < intent.uris.size
-                updateState { it.copy(selectedImageUris = it.selectedImageUris + toAdd) }
+                updateState { it.copy(selectedImageUris = it.selectedImageUris + toAdd, lastTouchedField = "images") }
                 if (hasOverflow) sendSideEffect(UploadSideEffect.ShowSnackbar("최대 ${MAX_IMAGE_COUNT}장까지 추가할 수 있어요"))
             }
             is UploadIntent.RemoveImage ->
@@ -71,6 +90,14 @@ class UploadViewModel @Inject constructor(
                     it.copy(showPhotoPickerSheet = intent.isVisible)
                 }
             UploadIntent.NavigateBack -> {
+                if (currentState.hasInput) {
+                    analytics.track(
+                        AnalyticsEvent.VoteCreateAbandoned(
+                            filledFields = currentState.filledFields,
+                            lastStep = currentState.lastTouchedField,
+                        ),
+                    )
+                }
                 updateState {
                     it.copy(showExitDialog = false, showCategorySheet = false)
                 }
@@ -133,7 +160,14 @@ class UploadViewModel @Inject constructor(
                     title = title,
                     link = link,
                 )
-            }.onSuccess {
+            }.onSuccess { feedId ->
+                analytics.track(
+                    AnalyticsEvent.VoteCreateCompleted(
+                        itemId = feedId,
+                        voteTitle = currentState.title,
+                        optionCount = currentState.selectedImageUris.size,
+                    ),
+                )
                 updateState { it.copy(isLoading = false) }
                 sendSideEffect(UploadSideEffect.NavigateToHomeReview)
             }.onFailure { throwable ->

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -40,6 +40,9 @@ googleid = "1.2.0"
 
 lottie = "6.7.1"
 
+# Analytics
+mixpanel = "7.5.3"
+
 # Firebase
 firebaseBom = "34.9.0"
 googleServices = "4.4.2"
@@ -127,6 +130,9 @@ firebase-crashlytics = { group = "com.google.firebase", name = "firebase-crashly
 firebase-config = { group = "com.google.firebase", name = "firebase-config" }
 
 lottie-compose = { group = "com.airbnb.android", name = "lottie-compose", version.ref = "lottie" }
+
+# Analytics
+mixpanel-android = { group = "com.mixpanel.android", name = "mixpanel-android", version.ref = "mixpanel" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -26,6 +26,7 @@ dependencyResolutionManagement {
 rootProject.name = "BuyOrNot"
 include(":app")
 include(":domain")
+include(":core:analytics")
 include(":core:data")
 include(":core:network")
 include(":core:datastore")


### PR DESCRIPTION
## 🛠 Related issue
closed #105

어떤 변경사항이 있었나요?
- [x] ✨ Feature Feature

## ✅ CheckPoint
- [x] PR 컨벤션에 맞게 작성했습니다. (필수)
- [x] merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕) (필수)
- [x] Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다. (필수)

## ✏️ Work Description

Mixpanel 기반 이벤트 로깅 시스템을 구축하고, 피드/투표 생성 흐름에 대한 이벤트를 연동합니다.

### 아키텍처
- `core/analytics` 신규 모듈 추가
- `Analytics` 인터페이스 + `AnalyticsEvent` sealed class
- Debug 빌드: `DebugAnalytics` (Logcat 출력)
- Release 빌드: `MixpanelAnalytics` (실제 전송)
- Hilt `SingletonComponent`로 DI, `local.properties`에서 `mixpanel.token` 읽음

### 로깅 이벤트

| 이벤트 | 발생 시점 | 속성 |
|---|---|---|
| `feed_viewed` | 피드 화면 진입 | `first_visible_item_index` |
| `feed_exited` | 피드 화면 이탈 | `time_spent_seconds`, `last_visible_item_index` |
| `vote_submitted` | 투표 버튼 탭 | `feed_id`, `vote_choice`, `feed_category` |
| `vote_create_started` | 투표 작성 화면 진입 | `entry_source`, `is_logged_in` |
| `vote_create_completed` | 투표 게시 성공 | `item_id`, `vote_title`, `option_count` |
| `vote_create_abandoned` | 작성 중 뒤로가기 확인 | `filled_fields`, `last_step` |

## 😅 Uncompleted Tasks
- N/A

## 📢 To Reviewers
- `MIXPANEL_TOKEN` secret을 GitHub Actions에 등록해야 CI/CD 빌드가 정상 동작합니다 (Settings → Secrets and variables → Actions)
- `local.properties`에 `mixpanel.token=<실제토큰>` 추가 필요 (로컬 빌드 시)
- Debug 빌드에서는 Mixpanel로 전송되지 않고 Logcat(`tag: Analytics`)에만 출력됩니다

## 📃 RCA 룰
- R: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
- C: 웬만하면 반영해 주세요. (Comment)
- A: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* **분석 기능 추가**
  * 피드 화면 진입/종료 시 사용자 활동 추적
  * 투표 제출 이벤트 추적
  * 투표 생성 워크플로우(시작, 완료, 중단) 추적

<!-- end of auto-generated comment: release notes by coderabbit.ai -->