### PR TITLE
fix/#107: SplashViewModel 업데이트 판별 로직 엣지 케이스 수정

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,3 +8,6 @@ trim_trailing_whitespace = true
 [*.{kt,kts}]
 ktlint_function_naming_ignore_when_annotated_with = Composable
 ktlint_standard_annotation = disabled
+
+[*Test.kt]
+ktlint_standard_function-naming = disabled

--- a/feature/auth/build.gradle.kts
+++ b/feature/auth/build.gradle.kts
@@ -33,4 +33,8 @@ dependencies {
 
     implementation(platform(libs.firebase.bom))
     implementation(libs.firebase.messaging)
+
+    testImplementation(libs.junit)
+    testImplementation(libs.kotlin.test)
+    testImplementation(libs.kotlinx.coroutines.test)
 }

--- a/feature/auth/src/main/java/com/sseotdabwa/buyornot/feature/auth/ui/SplashViewModel.kt
+++ b/feature/auth/src/main/java/com/sseotdabwa/buyornot/feature/auth/ui/SplashViewModel.kt
@@ -5,6 +5,7 @@ import android.util.Log
 import androidx.core.content.pm.PackageInfoCompat
 import androidx.lifecycle.viewModelScope
 import com.sseotdabwa.buyornot.core.ui.base.BaseViewModel
+import com.sseotdabwa.buyornot.domain.model.AppUpdateInfo
 import com.sseotdabwa.buyornot.domain.model.UpdateStrategy
 import com.sseotdabwa.buyornot.domain.model.UserType
 import com.sseotdabwa.buyornot.domain.repository.AppPreferencesRepository
@@ -25,7 +26,7 @@ private const val TAG = "SplashUpdate"
 
 internal fun resolveUpdateDialogType(
     currentVersion: Int,
-    updateInfo: com.sseotdabwa.buyornot.domain.model.AppUpdateInfo?,
+    updateInfo: AppUpdateInfo?,
     lastSoftUpdateShownTime: Long,
     now: Long,
 ): UpdateDialogType {
@@ -33,10 +34,12 @@ internal fun resolveUpdateDialogType(
 
     return when {
         currentVersion < updateInfo.minimumVersion -> UpdateDialogType.Force
+        // currentVersion >= latestVersion이면 이미 최신 버전이므로 FORCE 팝업 표시 안 함
         updateInfo.updateStrategy == UpdateStrategy.FORCE &&
             currentVersion < updateInfo.latestVersion -> UpdateDialogType.Force
         updateInfo.updateStrategy == UpdateStrategy.SOFT &&
             currentVersion < updateInfo.latestVersion -> {
+            // lastSoftUpdateShownTime이 미래 값이면 시계 역행으로 판단, 표시된 적 없는 것으로 처리
             val effectiveLastShown = if (lastSoftUpdateShownTime > now) 0L else lastSoftUpdateShownTime
             if (now - effectiveLastShown >= SOFT_UPDATE_INTERVAL_MILLIS) {
                 UpdateDialogType.Soft
@@ -118,7 +121,7 @@ class SplashViewModel @Inject constructor(
 
     private suspend fun determineDialogType(
         currentVersion: Int,
-        updateInfo: com.sseotdabwa.buyornot.domain.model.AppUpdateInfo?,
+        updateInfo: AppUpdateInfo?,
     ): UpdateDialogType {
         val now = System.currentTimeMillis()
         val lastShown = appPreferencesRepository.lastSoftUpdateShownTime.first()
@@ -129,6 +132,8 @@ class SplashViewModel @Inject constructor(
         viewModelScope.launch {
             try {
                 appPreferencesRepository.updateLastSoftUpdateShownTime(System.currentTimeMillis())
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to save soft update shown time", e)
             } finally {

--- a/feature/auth/src/main/java/com/sseotdabwa/buyornot/feature/auth/ui/SplashViewModel.kt
+++ b/feature/auth/src/main/java/com/sseotdabwa/buyornot/feature/auth/ui/SplashViewModel.kt
@@ -20,8 +20,33 @@ import javax.inject.Inject
 import kotlin.coroutines.cancellation.CancellationException
 
 private const val SPLASH_TIMEOUT_MILLIS = 2300L
-private const val SOFT_UPDATE_INTERVAL_MILLIS = 24 * 60 * 60 * 1000L
+internal const val SOFT_UPDATE_INTERVAL_MILLIS = 24 * 60 * 60 * 1000L
 private const val TAG = "SplashUpdate"
+
+internal fun resolveUpdateDialogType(
+    currentVersion: Int,
+    updateInfo: com.sseotdabwa.buyornot.domain.model.AppUpdateInfo?,
+    lastSoftUpdateShownTime: Long,
+    now: Long,
+): UpdateDialogType {
+    if (updateInfo == null) return UpdateDialogType.None
+
+    return when {
+        currentVersion < updateInfo.minimumVersion -> UpdateDialogType.Force
+        updateInfo.updateStrategy == UpdateStrategy.FORCE &&
+            currentVersion < updateInfo.latestVersion -> UpdateDialogType.Force
+        updateInfo.updateStrategy == UpdateStrategy.SOFT &&
+            currentVersion < updateInfo.latestVersion -> {
+            val effectiveLastShown = if (lastSoftUpdateShownTime > now) 0L else lastSoftUpdateShownTime
+            if (now - effectiveLastShown >= SOFT_UPDATE_INTERVAL_MILLIS) {
+                UpdateDialogType.Soft
+            } else {
+                UpdateDialogType.None
+            }
+        }
+        else -> UpdateDialogType.None
+    }
+}
 
 /**
  * 스플래시 화면을 위한 ViewModel
@@ -95,29 +120,17 @@ class SplashViewModel @Inject constructor(
         currentVersion: Int,
         updateInfo: com.sseotdabwa.buyornot.domain.model.AppUpdateInfo?,
     ): UpdateDialogType {
-        if (updateInfo == null) return UpdateDialogType.None
-
-        return when {
-            currentVersion < updateInfo.minimumVersion -> UpdateDialogType.Force
-            updateInfo.updateStrategy == UpdateStrategy.FORCE &&
-                currentVersion < updateInfo.latestVersion -> UpdateDialogType.Force
-            updateInfo.updateStrategy == UpdateStrategy.SOFT &&
-                currentVersion < updateInfo.latestVersion -> {
-                val lastShown = appPreferencesRepository.lastSoftUpdateShownTime.first()
-                if (System.currentTimeMillis() - lastShown >= SOFT_UPDATE_INTERVAL_MILLIS) {
-                    UpdateDialogType.Soft
-                } else {
-                    UpdateDialogType.None
-                }
-            }
-            else -> UpdateDialogType.None
-        }
+        val now = System.currentTimeMillis()
+        val lastShown = appPreferencesRepository.lastSoftUpdateShownTime.first()
+        return resolveUpdateDialogType(currentVersion, updateInfo, lastShown, now)
     }
 
     private fun dismissSoftUpdate() {
         viewModelScope.launch {
             try {
                 appPreferencesRepository.updateLastSoftUpdateShownTime(System.currentTimeMillis())
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to save soft update shown time", e)
             } finally {
                 updateState { it.copy(updateDialogType = UpdateDialogType.None) }
             }

--- a/feature/auth/src/main/java/com/sseotdabwa/buyornot/feature/auth/ui/SplashViewModel.kt
+++ b/feature/auth/src/main/java/com/sseotdabwa/buyornot/feature/auth/ui/SplashViewModel.kt
@@ -99,7 +99,8 @@ class SplashViewModel @Inject constructor(
 
         return when {
             currentVersion < updateInfo.minimumVersion -> UpdateDialogType.Force
-            updateInfo.updateStrategy == UpdateStrategy.FORCE -> UpdateDialogType.Force
+            updateInfo.updateStrategy == UpdateStrategy.FORCE &&
+                currentVersion < updateInfo.latestVersion -> UpdateDialogType.Force
             updateInfo.updateStrategy == UpdateStrategy.SOFT &&
                 currentVersion < updateInfo.latestVersion -> {
                 val lastShown = appPreferencesRepository.lastSoftUpdateShownTime.first()

--- a/feature/auth/src/test/java/com/sseotdabwa/buyornot/feature/auth/ui/SplashUpdateLogicTest.kt
+++ b/feature/auth/src/test/java/com/sseotdabwa/buyornot/feature/auth/ui/SplashUpdateLogicTest.kt
@@ -199,4 +199,22 @@ class SplashUpdateLogicTest {
             )
         }
     }
+
+    @Test
+    fun 최초_설치시_소프트_업데이트를_표시한다() {
+        // DataStore 기본값(0L)일 때 now - 0 >= SOFT_UPDATE_INTERVAL_MILLIS 이므로 Soft 반환
+        val result =
+            resolveUpdateDialogType(
+                currentVersion = 8,
+                updateInfo =
+                    AppUpdateInfo(
+                        latestVersion = 10,
+                        minimumVersion = 5,
+                        updateStrategy = UpdateStrategy.SOFT,
+                    ),
+                lastSoftUpdateShownTime = 0L,
+                now = SOFT_UPDATE_INTERVAL_MILLIS + 1L,
+            )
+        assertEquals(UpdateDialogType.Soft, result)
+    }
 }

--- a/feature/auth/src/test/java/com/sseotdabwa/buyornot/feature/auth/ui/SplashUpdateLogicTest.kt
+++ b/feature/auth/src/test/java/com/sseotdabwa/buyornot/feature/auth/ui/SplashUpdateLogicTest.kt
@@ -1,0 +1,202 @@
+package com.sseotdabwa.buyornot.feature.auth.ui
+
+import com.sseotdabwa.buyornot.domain.model.AppUpdateInfo
+import com.sseotdabwa.buyornot.domain.model.UpdateStrategy
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class SplashUpdateLogicTest {
+    private val now = 1_000_000_000L
+
+    @Test
+    fun updateInfo가_null이면_None을_반환한다() {
+        val result =
+            resolveUpdateDialogType(
+                currentVersion = 10,
+                updateInfo = null,
+                lastSoftUpdateShownTime = 0L,
+                now = now,
+            )
+        assertEquals(UpdateDialogType.None, result)
+    }
+
+    @Test
+    fun currentVersion이_minimumVersion_미만이면_Force를_반환한다() {
+        val result =
+            resolveUpdateDialogType(
+                currentVersion = 5,
+                updateInfo =
+                    AppUpdateInfo(
+                        latestVersion = 10,
+                        minimumVersion = 6,
+                        updateStrategy = UpdateStrategy.NONE,
+                    ),
+                lastSoftUpdateShownTime = 0L,
+                now = now,
+            )
+        assertEquals(UpdateDialogType.Force, result)
+    }
+
+    @Test
+    fun FORCE_전략이고_currentVersion이_latestVersion_미만이면_Force를_반환한다() {
+        val result =
+            resolveUpdateDialogType(
+                currentVersion = 8,
+                updateInfo =
+                    AppUpdateInfo(
+                        latestVersion = 10,
+                        minimumVersion = 5,
+                        updateStrategy = UpdateStrategy.FORCE,
+                    ),
+                lastSoftUpdateShownTime = 0L,
+                now = now,
+            )
+        assertEquals(UpdateDialogType.Force, result)
+    }
+
+    @Test
+    fun FORCE_전략이지만_currentVersion이_latestVersion_이상이면_None을_반환한다() {
+        val result =
+            resolveUpdateDialogType(
+                currentVersion = 10,
+                updateInfo =
+                    AppUpdateInfo(
+                        latestVersion = 10,
+                        minimumVersion = 5,
+                        updateStrategy = UpdateStrategy.FORCE,
+                    ),
+                lastSoftUpdateShownTime = 0L,
+                now = now,
+            )
+        assertEquals(UpdateDialogType.None, result)
+    }
+
+    @Test
+    fun FORCE_전략이고_minimumVersion_이상_latestVersion_미만이면_Force를_반환한다() {
+        val result =
+            resolveUpdateDialogType(
+                currentVersion = 7,
+                updateInfo =
+                    AppUpdateInfo(
+                        latestVersion = 10,
+                        minimumVersion = 5,
+                        updateStrategy = UpdateStrategy.FORCE,
+                    ),
+                lastSoftUpdateShownTime = 0L,
+                now = now,
+            )
+        assertEquals(UpdateDialogType.Force, result)
+    }
+
+    @Test
+    fun SOFT_전략이고_24시간_이상_지났으면_Soft를_반환한다() {
+        val lastShown = now - SOFT_UPDATE_INTERVAL_MILLIS
+        val result =
+            resolveUpdateDialogType(
+                currentVersion = 8,
+                updateInfo =
+                    AppUpdateInfo(
+                        latestVersion = 10,
+                        minimumVersion = 5,
+                        updateStrategy = UpdateStrategy.SOFT,
+                    ),
+                lastSoftUpdateShownTime = lastShown,
+                now = now,
+            )
+        assertEquals(UpdateDialogType.Soft, result)
+    }
+
+    @Test
+    fun SOFT_전략이지만_24시간_미만이면_None을_반환한다() {
+        val lastShown = now - SOFT_UPDATE_INTERVAL_MILLIS + 1
+        val result =
+            resolveUpdateDialogType(
+                currentVersion = 8,
+                updateInfo =
+                    AppUpdateInfo(
+                        latestVersion = 10,
+                        minimumVersion = 5,
+                        updateStrategy = UpdateStrategy.SOFT,
+                    ),
+                lastSoftUpdateShownTime = lastShown,
+                now = now,
+            )
+        assertEquals(UpdateDialogType.None, result)
+    }
+
+    @Test
+    fun SOFT_전략이지만_currentVersion이_latestVersion_이상이면_None을_반환한다() {
+        val result =
+            resolveUpdateDialogType(
+                currentVersion = 10,
+                updateInfo =
+                    AppUpdateInfo(
+                        latestVersion = 10,
+                        minimumVersion = 5,
+                        updateStrategy = UpdateStrategy.SOFT,
+                    ),
+                lastSoftUpdateShownTime = 0L,
+                now = now,
+            )
+        assertEquals(UpdateDialogType.None, result)
+    }
+
+    @Test
+    fun 시계가_역행했을때_lastShown이_무효화되어_Soft를_반환한다() {
+        // lastSoftUpdateShownTime이 now보다 미래인 경우 (시계 역행) → effectiveLastShown = 0 → 항상 Soft
+        val lastShownInFuture = now + 1_000L
+        val result =
+            resolveUpdateDialogType(
+                currentVersion = 8,
+                updateInfo =
+                    AppUpdateInfo(
+                        latestVersion = 10,
+                        minimumVersion = 5,
+                        updateStrategy = UpdateStrategy.SOFT,
+                    ),
+                lastSoftUpdateShownTime = lastShownInFuture,
+                now = now,
+            )
+        assertEquals(UpdateDialogType.Soft, result)
+    }
+
+    @Test
+    fun NONE_전략이면_None을_반환한다() {
+        val result =
+            resolveUpdateDialogType(
+                currentVersion = 8,
+                updateInfo =
+                    AppUpdateInfo(
+                        latestVersion = 10,
+                        minimumVersion = 5,
+                        updateStrategy = UpdateStrategy.NONE,
+                    ),
+                lastSoftUpdateShownTime = 0L,
+                now = now,
+            )
+        assertEquals(UpdateDialogType.None, result)
+    }
+
+    @Test
+    fun minimumVersion_미달이면_전략_무관하게_Force를_반환한다() {
+        for (strategy in UpdateStrategy.entries) {
+            val result =
+                resolveUpdateDialogType(
+                    currentVersion = 3,
+                    updateInfo =
+                        AppUpdateInfo(
+                            latestVersion = 10,
+                            minimumVersion = 5,
+                            updateStrategy = strategy,
+                        ),
+                    lastSoftUpdateShownTime = 0L,
+                    now = now,
+                )
+            assertEquals(
+                UpdateDialogType.Force,
+                result,
+                "strategy=$strategy 일 때 minimumVersion 미달은 Force여야 함",
+            )
+        }
+    }
+}


### PR DESCRIPTION
## 🛠 Related issue
closed #107

어떤 변경사항이 있었나요?
- [x] 🐞 BugFix Something isn't working
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [ ] ✨ Feature Feature
- [x] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [x] ✅ Test Test related (Junit, etc.)

## ✅ CheckPoint
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 컨벤션에 맞게 작성했습니다. (필수)
- [x] merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕) (필수)
- [x] Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다. (필수)
- [x] BugFix의 경우, 버그의 원인을 파악하였습니다. (선택)

## ✏️ Work Description
`SplashViewModel.determineDialogType`에서 발견된 3가지 엣지 케이스 수정

- **[Fix 1] FORCE 전략 + 버전 조건 추가**
  - 기존: `updateStrategy == FORCE`이면 현재 버전과 무관하게 항상 강제 업데이트 팝업 표시
  - 수정: `currentVersion < latestVersion`일 때만 FORCE 팝업 표시 (이미 최신 버전이면 스킵)

- **[Fix 2] 디바이스 시계 역행 시 소프트 업데이트 영구 미표시 버그 수정**
  - 기존: `currentTime - lastShown < 0`이면 24시간 조건 불만족 → 소프트 업데이트 영원히 미표시
  - 수정: `lastShown > now`이면 `effectiveLastShown = 0`으로 처리하여 즉시 표시

- **[Fix 3] `dismissSoftUpdate` DataStore 저장 실패 시 무음 처리 개선**
  - 기존: 저장 실패 예외를 조용히 삼킴
  - 수정: `Log.e`로 에러 기록 + `CancellationException` 명시적 재전파

- **[Refactor] 순수 결정 로직 추출**
  - `resolveUpdateDialogType` internal 함수로 분리 (Android 의존성 없음)
  - ViewModel은 DataStore에서 읽은 값을 파라미터로 전달하여 위임

- **[Test] 업데이트 판별 로직 유닛 테스트 12개 추가**
  - `SplashUpdateLogicTest` — 모든 전략/버전 조합 및 시계 역행, 최초 설치 케이스 커버

## 😅 Uncompleted Tasks
- N/A

## 📢 To Reviewers
- `resolveUpdateDialogType`이 `internal`인 이유: Kotlin top-level `private`은 파일-private이라 동일 모듈의 다른 파일(테스트)에서 접근 불가. `internal`이 테스트 접근을 위한 최소 공개 범위입니다.
- Fix 1의 동작 변경: FORCE 전략이라도 `currentVersion >= latestVersion`이면 팝업을 표시하지 않습니다. 서버에서 이미 최신 버전인 유저에게 FORCE를 보내는 경우는 잘못된 서버 설정으로 간주하여 클라이언트에서 방어합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 앱 업데이트 대화상자의 버전 비교 로직이 개선되었습니다.
  * 소프트 업데이트 표시 시간 처리가 더욱 안정적으로 작동합니다.

* **테스트**
  * 앱 업데이트 대화상자 동작 검증을 위한 포괄적인 테스트 스위트가 추가되었습니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Nexters/BuyOrNot-Android/pull/108)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->