### PR TITLE
Fix/#111: MixPanel 슈퍼 속성 누락 및 FeedExited lastVisibleItemIndex 오류 수정

### DIFF
--- a/app/src/main/java/com/sseotdabwa/buyornot/ui/BuyOrNotViewModel.kt
+++ b/app/src/main/java/com/sseotdabwa/buyornot/ui/BuyOrNotViewModel.kt
@@ -2,9 +2,14 @@ package com.sseotdabwa.buyornot.ui
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.sseotdabwa.buyornot.core.analytics.Analytics
 import com.sseotdabwa.buyornot.domain.repository.AppPreferencesRepository
+import com.sseotdabwa.buyornot.domain.repository.UserPreferencesRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -12,6 +17,8 @@ import javax.inject.Inject
 @HiltViewModel
 class BuyOrNotViewModel @Inject constructor(
     private val appPreferencesRepository: AppPreferencesRepository,
+    private val userPreferencesRepository: UserPreferencesRepository,
+    private val analytics: Analytics,
 ) : ViewModel() {
     val isFirstRun =
         appPreferencesRepository.isFirstRun
@@ -20,6 +27,14 @@ class BuyOrNotViewModel @Inject constructor(
                 started = SharingStarted.WhileSubscribed(5000),
                 initialValue = false,
             )
+
+    init {
+        userPreferencesRepository.userId
+            .distinctUntilChanged()
+            .onEach { userId ->
+                analytics.identify(if (userId != 0L) userId.toString() else null)
+            }.launchIn(viewModelScope)
+    }
 
     fun updateIsFirstRun(isFirstRun: Boolean) {
         viewModelScope.launch {

--- a/core/analytics/src/main/java/com/sseotdabwa/buyornot/core/analytics/Analytics.kt
+++ b/core/analytics/src/main/java/com/sseotdabwa/buyornot/core/analytics/Analytics.kt
@@ -2,4 +2,6 @@ package com.sseotdabwa.buyornot.core.analytics
 
 interface Analytics {
     fun track(event: AnalyticsEvent)
+
+    fun identify(userId: String?)
 }

--- a/core/analytics/src/main/java/com/sseotdabwa/buyornot/core/analytics/DebugAnalytics.kt
+++ b/core/analytics/src/main/java/com/sseotdabwa/buyornot/core/analytics/DebugAnalytics.kt
@@ -6,4 +6,8 @@ class DebugAnalytics : Analytics {
     override fun track(event: AnalyticsEvent) {
         Log.d("Analytics", event.toString())
     }
+
+    override fun identify(userId: String?) {
+        Log.d("Analytics", "identify: userId=$userId")
+    }
 }

--- a/core/analytics/src/main/java/com/sseotdabwa/buyornot/core/analytics/MixpanelAnalytics.kt
+++ b/core/analytics/src/main/java/com/sseotdabwa/buyornot/core/analytics/MixpanelAnalytics.kt
@@ -6,10 +6,30 @@ import org.json.JSONObject
 
 class MixpanelAnalytics(
     private val mixpanel: MixpanelAPI,
+    appVersion: String,
 ) : Analytics {
+    init {
+        mixpanel.registerSuperProperties(
+            JSONObject().apply {
+                put("platform", "android")
+                put("app_version", appVersion)
+                put("user_id", JSONObject.NULL)
+            },
+        )
+    }
+
     override fun track(event: AnalyticsEvent) {
         val (name, props) = event.toMixpanel()
         mixpanel.track(name, props)
+    }
+
+    override fun identify(userId: String?) {
+        if (userId != null) {
+            mixpanel.identify(userId)
+        }
+        mixpanel.registerSuperProperties(
+            JSONObject().apply { put("user_id", userId ?: JSONObject.NULL) },
+        )
     }
 
     private fun AnalyticsEvent.toMixpanel(): Pair<String, JSONObject> {

--- a/core/analytics/src/main/java/com/sseotdabwa/buyornot/core/analytics/di/AnalyticsModule.kt
+++ b/core/analytics/src/main/java/com/sseotdabwa/buyornot/core/analytics/di/AnalyticsModule.kt
@@ -30,6 +30,11 @@ object AnalyticsModule {
                     BuildConfig.MIXPANEL_TOKEN,
                     true,
                 )
-            MixpanelAnalytics(mixpanel)
+            val appVersion =
+                context.packageManager
+                    .getPackageInfo(context.packageName, 0)
+                    .versionName
+                    ?: "unknown"
+            MixpanelAnalytics(mixpanel, appVersion)
         }
 }

--- a/core/data/src/main/java/com/sseotdabwa/buyornot/core/data/repository/UserPreferencesRepositoryImpl.kt
+++ b/core/data/src/main/java/com/sseotdabwa/buyornot/core/data/repository/UserPreferencesRepositoryImpl.kt
@@ -27,8 +27,14 @@ class UserPreferencesRepositoryImpl @Inject constructor(
     override val userType: Flow<UserType> =
         userPreferencesDataSource.userType.map { it.toDomain() }
 
+    override val userId: Flow<Long> = userPreferencesDataSource.userId
+
     override suspend fun updateUserType(userType: UserType) {
         userPreferencesDataSource.updateUserType(userType.toDatastore())
+    }
+
+    override suspend fun updateUserId(userId: Long) {
+        userPreferencesDataSource.updateUserId(userId)
     }
 
     override suspend fun updateDisplayName(newName: String) {

--- a/core/datastore/src/main/java/com/sseotdabwa/buyornot/core/datastore/UserPreferences.kt
+++ b/core/datastore/src/main/java/com/sseotdabwa/buyornot/core/datastore/UserPreferences.kt
@@ -14,6 +14,7 @@ enum class UserType {
  * 사용자 프로필 및 인증 토큰을 관리합니다.
  */
 data class UserPreferences(
+    val userId: Long = 0L,
     val displayName: String = "손님",
     val profileImageUrl: String = "",
     val accessToken: String = "",

--- a/core/datastore/src/main/java/com/sseotdabwa/buyornot/core/datastore/UserPreferencesDataSource.kt
+++ b/core/datastore/src/main/java/com/sseotdabwa/buyornot/core/datastore/UserPreferencesDataSource.kt
@@ -14,6 +14,10 @@ interface UserPreferencesDataSource {
 
     val userType: Flow<UserType>
 
+    val userId: Flow<Long>
+
+    suspend fun updateUserId(userId: Long)
+
     suspend fun updateDisplayName(newName: String)
 
     suspend fun updateProfileImageUrl(newUrl: String)

--- a/core/datastore/src/main/java/com/sseotdabwa/buyornot/core/datastore/UserPreferencesDataSourceImpl.kt
+++ b/core/datastore/src/main/java/com/sseotdabwa/buyornot/core/datastore/UserPreferencesDataSourceImpl.kt
@@ -2,6 +2,7 @@ package com.sseotdabwa.buyornot.core.datastore
 
 import android.content.Context
 import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.longPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -22,6 +23,7 @@ class UserPreferencesDataSourceImpl @Inject constructor(
     @ApplicationContext private val context: Context,
 ) : UserPreferencesDataSource {
     private object Keys {
+        val USER_ID = longPreferencesKey("user_id")
         val DISPLAY_NAME = stringPreferencesKey("display_name")
         val PROFILE_IMAGE_URL = stringPreferencesKey("profile_image_url")
         val ACCESS_TOKEN = stringPreferencesKey("access_token")
@@ -32,6 +34,7 @@ class UserPreferencesDataSourceImpl @Inject constructor(
     override val preferences: Flow<UserPreferences> =
         context.userPreferencesDataStore.data.map { prefs ->
             UserPreferences(
+                userId = prefs[Keys.USER_ID] ?: UserPreferences().userId,
                 displayName = prefs[Keys.DISPLAY_NAME] ?: UserPreferences().displayName,
                 profileImageUrl = prefs[Keys.PROFILE_IMAGE_URL] ?: UserPreferences().profileImageUrl,
                 accessToken = prefs[Keys.ACCESS_TOKEN] ?: UserPreferences().accessToken,
@@ -47,6 +50,9 @@ class UserPreferencesDataSourceImpl @Inject constructor(
             )
         }
 
+    override val userId: Flow<Long> =
+        context.userPreferencesDataStore.data.map { it[Keys.USER_ID] ?: 0L }
+
     override val accessToken: Flow<String> = context.userPreferencesDataStore.data.map { it[Keys.ACCESS_TOKEN] ?: "" }
 
     override val userType: Flow<UserType> =
@@ -59,6 +65,12 @@ class UserPreferencesDataSourceImpl @Inject constructor(
                 }
             } ?: UserType.GUEST
         }
+
+    override suspend fun updateUserId(userId: Long) {
+        context.userPreferencesDataStore.edit { prefs ->
+            prefs[Keys.USER_ID] = userId
+        }
+    }
 
     override suspend fun updateDisplayName(newName: String) {
         context.userPreferencesDataStore.edit { prefs ->
@@ -90,6 +102,7 @@ class UserPreferencesDataSourceImpl @Inject constructor(
 
     override suspend fun clearUserInfo() {
         context.userPreferencesDataStore.edit { prefs ->
+            prefs.remove(Keys.USER_ID)
             prefs.remove(Keys.ACCESS_TOKEN)
             prefs.remove(Keys.REFRESH_TOKEN)
             prefs.remove(Keys.PROFILE_IMAGE_URL)

--- a/domain/src/main/java/com/sseotdabwa/buyornot/domain/repository/UserPreferencesRepository.kt
+++ b/domain/src/main/java/com/sseotdabwa/buyornot/domain/repository/UserPreferencesRepository.kt
@@ -25,9 +25,19 @@ interface UserPreferencesRepository {
     val userType: Flow<UserType>
 
     /**
+     * 현재 로그인된 사용자 ID를 Flow로 제공 (비로그인 시 0L)
+     */
+    val userId: Flow<Long>
+
+    /**
      * 사용자 타입 업데이트
      */
     suspend fun updateUserType(userType: UserType)
+
+    /**
+     * 사용자 ID 업데이트
+     */
+    suspend fun updateUserId(userId: Long)
 
     /**
      * 표시 이름 업데이트

--- a/feature/auth/src/main/java/com/sseotdabwa/buyornot/feature/auth/ui/LoginViewModel.kt
+++ b/feature/auth/src/main/java/com/sseotdabwa/buyornot/feature/auth/ui/LoginViewModel.kt
@@ -173,6 +173,7 @@ class LoginViewModel @Inject constructor(
         runCatchingCancellable {
             userRepository.getMyProfile()
         }.onSuccess { profile ->
+            userPreferencesRepository.updateUserId(profile.id)
             userPreferencesRepository.updateDisplayName(profile.nickname)
             userPreferencesRepository.updateProfileImageUrl(profile.profileImage)
         }.onFailure { e ->

--- a/feature/home/src/main/java/com/sseotdabwa/buyornot/feature/home/ui/HomeScreen.kt
+++ b/feature/home/src/main/java/com/sseotdabwa/buyornot/feature/home/ui/HomeScreen.kt
@@ -38,6 +38,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -366,8 +367,9 @@ private fun HomeFeedList(
     val isEmptyViewVisible = filteredFeeds.isEmpty() && !uiState.isLoading && !uiState.hasError
     val isMyFeedEmpty = uiState.selectedTab == HomeTab.MY_FEED && isEmptyViewVisible
 
-    val enterTimeMs = remember { System.currentTimeMillis() }
+    var enterTimeMs by remember { mutableLongStateOf(System.currentTimeMillis()) }
     LifecycleEventEffect(Lifecycle.Event.ON_START) {
+        enterTimeMs = System.currentTimeMillis()
         onIntent(HomeIntent.OnFeedScreenEntered(firstVisibleItemIndex = listState.firstVisibleItemIndex))
     }
     LifecycleEventEffect(Lifecycle.Event.ON_STOP) {

--- a/feature/home/src/main/java/com/sseotdabwa/buyornot/feature/home/ui/HomeScreen.kt
+++ b/feature/home/src/main/java/com/sseotdabwa/buyornot/feature/home/ui/HomeScreen.kt
@@ -371,7 +371,11 @@ private fun HomeFeedList(
         onDispose {
             onIntent(
                 HomeIntent.OnFeedScreenExited(
-                    lastVisibleItemIndex = listState.firstVisibleItemIndex,
+                    lastVisibleItemIndex =
+                        listState.layoutInfo.visibleItemsInfo
+                            .lastOrNull()
+                            ?.index
+                            ?: listState.firstVisibleItemIndex,
                     timeSpentSeconds = (System.currentTimeMillis() - enterTimeMs) / 1000f,
                 ),
             )

--- a/feature/home/src/main/java/com/sseotdabwa/buyornot/feature/home/ui/HomeScreen.kt
+++ b/feature/home/src/main/java/com/sseotdabwa/buyornot/feature/home/ui/HomeScreen.kt
@@ -34,7 +34,6 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
@@ -60,6 +59,8 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LifecycleEventEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.sseotdabwa.buyornot.core.designsystem.components.ButtonSize
 import com.sseotdabwa.buyornot.core.designsystem.components.BuyOrNotAlertDialog
@@ -366,20 +367,20 @@ private fun HomeFeedList(
     val isMyFeedEmpty = uiState.selectedTab == HomeTab.MY_FEED && isEmptyViewVisible
 
     val enterTimeMs = remember { System.currentTimeMillis() }
-    DisposableEffect(Unit) {
+    LifecycleEventEffect(Lifecycle.Event.ON_START) {
         onIntent(HomeIntent.OnFeedScreenEntered(firstVisibleItemIndex = listState.firstVisibleItemIndex))
-        onDispose {
-            onIntent(
-                HomeIntent.OnFeedScreenExited(
-                    lastVisibleItemIndex =
-                        listState.layoutInfo.visibleItemsInfo
-                            .lastOrNull()
-                            ?.index
-                            ?: listState.firstVisibleItemIndex,
-                    timeSpentSeconds = (System.currentTimeMillis() - enterTimeMs) / 1000f,
-                ),
-            )
-        }
+    }
+    LifecycleEventEffect(Lifecycle.Event.ON_STOP) {
+        onIntent(
+            HomeIntent.OnFeedScreenExited(
+                lastVisibleItemIndex =
+                    listState.layoutInfo.visibleItemsInfo
+                        .lastOrNull()
+                        ?.index
+                        ?: listState.firstVisibleItemIndex,
+                timeSpentSeconds = (System.currentTimeMillis() - enterTimeMs) / 1000f,
+            ),
+        )
     }
     var headerHeightPx by remember { mutableIntStateOf(0) }
     val density = LocalDensity.current


### PR DESCRIPTION
## 🛠 Related issue
closed #111

어떤 변경사항이 있었나요?
- [x] 🐞 BugFix Something isn't working

## ✅ CheckPoint
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 컨벤션에 맞게 작성했습니다. (필수)
- [x] merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕) (필수)
- [x] Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다. (필수)
- [x] BugFix의 경우, 버그의 원인을 파악하였습니다. (선택)

## ✏️ Work Description
- `MixpanelAnalytics` 초기화 시 `platform("android")`, `app_version` 슈퍼 속성 등록
- `Analytics.identify(userId)` 인터페이스 추가 — 로그인/로그아웃 시 `user_id` 슈퍼 속성 갱신 (비로그인 시 `null`)
- `UserPreferencesDataStore`에 `userId` 저장 추가 — 로그인 후 `users/me` 응답의 userId를 DataStore에 영속화
- `BuyOrNotViewModel`에서 `userId` Flow 구독 → `analytics.identify()` 호출로 앱 전역에서 사용자 식별 유지
- `HomeScreen.kt` `lastVisibleItemIndex`를 `listState.firstVisibleItemIndex` 대신 `listState.layoutInfo.visibleItemsInfo.lastOrNull()?.index`로 수정
- `DisposableEffect(Unit)` → `LifecycleEventEffect(ON_STOP)` 교체 — saveState 네비게이션 환경에서 `onDispose`가 호출되지 않아 `feed_exited` 이벤트가 누락되던 문제 수정

## 😅 Uncompleted Tasks
N/A

## 📢 To Reviewers
- `user_id` 슈퍼 속성은 `String?`으로, 비로그인 상태에서는 `JSONObject.NULL`로 Mixpanel에 등록되어 속성 자체는 유지되지만 null 값으로 전송됩니다.
- `app_version`은 `AnalyticsModule`에서 `PackageManager`로 런타임에 가져오며 DI로 주입합니다.
- `feed_exited` 누락 원인: Jetpack Navigation의 `saveState = true` 설정 시 홈 화면이 Composition에서 제거되지 않아 `DisposableEffect.onDispose`가 호출되지 않았습니다. `LifecycleEventEffect(ON_STOP)` 으로 변경하여 다른 탭 이동 및 백그라운드 전환 시 모두 정상 호출됩니다.