### PR TITLE
Feat/#116: 이미지 크롭·편집 플로우 개선

### DIFF
--- a/core/ui/src/main/java/com/sseotdabwa/buyornot/core/ui/crop/EditNavigation.kt
+++ b/core/ui/src/main/java/com/sseotdabwa/buyornot/core/ui/crop/EditNavigation.kt
@@ -5,18 +5,27 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import androidx.navigation.toRoute
+import com.sseotdabwa.buyornot.core.ui.crop.state.AspectRatio
+import com.sseotdabwa.buyornot.core.ui.crop.state.CropSpec
+import com.sseotdabwa.buyornot.core.ui.crop.state.EditSpec
+import com.sseotdabwa.buyornot.core.ui.crop.state.NormalizedRect
 import kotlinx.serialization.Serializable
 
 const val EDIT_RESULT_KEY = "editResult"
+const val EDIT_RESULT_SPEC_KEY = "editResultSpec"
 const val EDIT_RESULT_SKIPPED = "SKIPPED"
 
 @Serializable
 data class EditRoute(
     val encodedUri: String,
+    val editSpecArg: String = "",
 )
 
-fun NavController.navigateToEdit(uri: Uri) {
-    navigate(EditRoute(encodedUri = uri.toString()))
+fun NavController.navigateToEdit(
+    uri: Uri,
+    editSpec: EditSpec = EditSpec(),
+) {
+    navigate(EditRoute(encodedUri = uri.toString(), editSpecArg = editSpec.encodeToArg()))
 }
 
 fun NavGraphBuilder.editScreen(navController: NavController) {
@@ -25,10 +34,12 @@ fun NavGraphBuilder.editScreen(navController: NavController) {
         val imageUri = Uri.parse(route.encodedUri)
         EditScreen(
             imageUri = imageUri,
-            onConfirm = { editedUri ->
-                navController.previousBackStackEntry
-                    ?.savedStateHandle
-                    ?.set(EDIT_RESULT_KEY, editedUri.toString())
+            initialSpec = decodeEditSpecArg(route.editSpecArg),
+            onConfirm = { editedUri, editSpec ->
+                navController.previousBackStackEntry?.savedStateHandle?.apply {
+                    set(EDIT_RESULT_KEY, editedUri.toString())
+                    set(EDIT_RESULT_SPEC_KEY, editSpec.encodeToArg())
+                }
                 navController.popBackStack()
             },
             onCancel = {
@@ -40,3 +51,40 @@ fun NavGraphBuilder.editScreen(navController: NavController) {
         )
     }
 }
+
+/**
+ * EditSpec을 네비게이션 인자로 실어 보내기 위한 경량 문자열 인코딩.
+ * 형식: "rotationQuarters[;ratioName;left;top;right;bottom]" (crop 없으면 회전값만).
+ */
+fun EditSpec.encodeToArg(): String =
+    buildString {
+        append(rotationQuarters)
+        crop?.let { c ->
+            append(SPEC_DELIMITER)
+            append(c.ratio.name)
+            append(SPEC_DELIMITER).append(c.rectNormalized.left)
+            append(SPEC_DELIMITER).append(c.rectNormalized.top)
+            append(SPEC_DELIMITER).append(c.rectNormalized.right)
+            append(SPEC_DELIMITER).append(c.rectNormalized.bottom)
+        }
+    }
+
+fun decodeEditSpecArg(arg: String?): EditSpec {
+    if (arg.isNullOrEmpty()) return EditSpec()
+    val parts = arg.split(SPEC_DELIMITER)
+    val quarters = parts.getOrNull(0)?.toIntOrNull() ?: 0
+    if (parts.size < 6) return EditSpec(rotationQuarters = quarters, crop = null)
+    val ratio = runCatching { AspectRatio.valueOf(parts[1]) }.getOrDefault(AspectRatio.Free)
+    val rect =
+        runCatching {
+            NormalizedRect(
+                left = parts[2].toFloat(),
+                top = parts[3].toFloat(),
+                right = parts[4].toFloat(),
+                bottom = parts[5].toFloat(),
+            )
+        }.getOrNull() ?: return EditSpec(rotationQuarters = quarters, crop = null)
+    return EditSpec(rotationQuarters = quarters, crop = CropSpec(ratio, rect))
+}
+
+private const val SPEC_DELIMITER = ";"

--- a/core/ui/src/main/java/com/sseotdabwa/buyornot/core/ui/crop/EditScreen.kt
+++ b/core/ui/src/main/java/com/sseotdabwa/buyornot/core/ui/crop/EditScreen.kt
@@ -35,15 +35,16 @@ import kotlinx.coroutines.launch
 @Composable
 fun EditScreen(
     imageUri: Uri,
-    onConfirm: (Uri) -> Unit,
+    onConfirm: (Uri, EditSpec) -> Unit,
     onCancel: () -> Unit,
+    initialSpec: EditSpec = EditSpec(),
 ) {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
     val snackbarHostState = remember { SnackbarHostState() }
 
     var mode by remember { mutableStateOf(EditMode.Idle) }
-    var editSpec by remember { mutableStateOf(EditSpec()) }
+    var editSpec by remember { mutableStateOf(initialSpec) }
     var isProcessing by remember { mutableStateOf(false) }
     var pendingError by remember { mutableStateOf<String?>(null) }
 
@@ -80,7 +81,7 @@ fun EditScreen(
                                 val result = processToFile(context, imageUri, editSpec)
                                 isProcessing = false
                                 result.fold(
-                                    onSuccess = { onConfirm(it) },
+                                    onSuccess = { onConfirm(it, editSpec) },
                                     onFailure = { pendingError = it.message ?: "이미지 처리에 실패했습니다" },
                                 )
                             }
@@ -143,7 +144,7 @@ fun EditScreen(
 private fun EditScreenIdlePreview() {
     EditScreen(
         imageUri = Uri.EMPTY,
-        onConfirm = {},
+        onConfirm = { _, _ -> },
         onCancel = {},
     )
 }

--- a/core/ui/src/main/java/com/sseotdabwa/buyornot/core/ui/crop/ui/CropPane.kt
+++ b/core/ui/src/main/java/com/sseotdabwa/buyornot/core/ui/crop/ui/CropPane.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
@@ -46,6 +47,10 @@ internal fun CropPane(
     modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
+    // CropOverlay의 코너 dot indicator가 잘리지 않도록 이미지를 안쪽으로 들이는 여백.
+    // imageBounds 계산도 동일한 여백을 사용해 CropOverlay 최대 영역이 실제 이미지 영역과 일치하도록 한다.
+    val imageInset = 12.dp
+    val imageInsetPx = with(LocalDensity.current) { imageInset.toPx() }
     var tempRatio by remember { mutableStateOf(editSpec.crop?.ratio ?: AspectRatio.Free) }
     var tempRect by remember {
         mutableStateOf(editSpec.crop?.rectNormalized ?: NormalizedRect.Full)
@@ -78,9 +83,13 @@ internal fun CropPane(
     }
 
     val imageBounds: Rect? =
-        remember(containerSize, intrinsicSize) {
+        remember(containerSize, intrinsicSize, imageInsetPx) {
             if (containerSize == IntSize.Zero || intrinsicSize == Size.Unspecified) return@remember null
-            val scale = minOf(containerSize.width / intrinsicSize.width, containerSize.height / intrinsicSize.height)
+            // 이미지는 inset 여백을 제외한 영역에 Fit으로 그려지므로, 그 영역 기준으로 스케일을 계산한다.
+            val availableWidth = containerSize.width - 2 * imageInsetPx
+            val availableHeight = containerSize.height - 2 * imageInsetPx
+            if (availableWidth <= 0f || availableHeight <= 0f) return@remember null
+            val scale = minOf(availableWidth / intrinsicSize.width, availableHeight / intrinsicSize.height)
             val displayedWidth = intrinsicSize.width * scale
             val displayedHeight = intrinsicSize.height * scale
             val left = (containerSize.width - displayedWidth) / 2f
@@ -100,6 +109,7 @@ internal fun CropPane(
                     .fillMaxWidth()
                     .weight(1f)
                     .padding(horizontal = 20.dp)
+                    .padding(top = 12.dp)
                     .onSizeChanged { containerSize = it },
             contentAlignment = Alignment.Center,
         ) {
@@ -107,7 +117,10 @@ internal fun CropPane(
                 Image(
                     bitmap = it.asImageBitmap(),
                     contentDescription = null,
-                    modifier = Modifier.fillMaxSize(),
+                    modifier =
+                        Modifier
+                            .fillMaxSize()
+                            .padding(imageInset),
                     contentScale = ContentScale.Fit,
                 )
             }

--- a/core/ui/src/main/java/com/sseotdabwa/buyornot/core/ui/crop/ui/CropRatioBar.kt
+++ b/core/ui/src/main/java/com/sseotdabwa/buyornot/core/ui/crop/ui/CropRatioBar.kt
@@ -36,7 +36,7 @@ internal fun CropRatioBar(
                 .fillMaxWidth()
                 .background(Color.Black)
                 .padding(
-                    top = 36.dp,
+                    top = 24.dp,
                     bottom = 56.dp,
                 ),
         horizontalArrangement =

--- a/core/ui/src/main/java/com/sseotdabwa/buyornot/core/ui/imageviewer/ImageViewerScreen.kt
+++ b/core/ui/src/main/java/com/sseotdabwa/buyornot/core/ui/imageviewer/ImageViewerScreen.kt
@@ -13,11 +13,7 @@ import androidx.compose.foundation.gestures.calculatePan
 import androidx.compose.foundation.gestures.calculateZoom
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
@@ -108,39 +104,13 @@ fun ImageViewerScreen(
         )
     val scope = rememberCoroutineScope()
 
-    Column(
+    Box(
         modifier =
             Modifier
                 .fillMaxSize()
                 .background(Color.Black),
     ) {
-        Box(
-            modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .statusBarsPadding()
-                    .height(60.dp),
-            contentAlignment = Alignment.CenterStart,
-        ) {
-            Box(
-                modifier =
-                    Modifier
-                        .align(Alignment.TopStart)
-                        .padding(start = 10.dp, top = 10.dp)
-                        .size(40.dp)
-                        .clickable(onClick = onBackClick),
-                contentAlignment = Alignment.Center,
-            ) {
-                Icon(
-                    imageVector = BuyOrNotIcons.Close.asImageVector(),
-                    contentDescription = "Close",
-                    tint = Color.White,
-                    modifier = Modifier.size(20.dp),
-                )
-            }
-        }
-
-        Box(modifier = Modifier.fillMaxSize().weight(1f)) {
+        Box(modifier = Modifier.fillMaxSize()) {
             HorizontalPager(
                 state = pagerState,
                 modifier = Modifier.fillMaxSize(),
@@ -193,10 +163,20 @@ fun ImageViewerScreen(
         Box(
             modifier =
                 Modifier
-                    .fillMaxWidth()
-                    .navigationBarsPadding()
-                    .height(60.dp),
-        )
+                    .align(Alignment.TopStart)
+                    .statusBarsPadding()
+                    .padding(start = 10.dp, top = 10.dp)
+                    .size(40.dp)
+                    .clickable(onClick = onBackClick),
+            contentAlignment = Alignment.Center,
+        ) {
+            Icon(
+                imageVector = BuyOrNotIcons.Close.asImageVector(),
+                contentDescription = "Close",
+                tint = Color.White,
+                modifier = Modifier.size(20.dp),
+            )
+        }
     }
 }
 

--- a/feature/upload/src/main/java/com/sseotdabwa/buyornot/feature/upload/navigation/UploadNavigation.kt
+++ b/feature/upload/src/main/java/com/sseotdabwa/buyornot/feature/upload/navigation/UploadNavigation.kt
@@ -11,6 +11,8 @@ import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
 import com.sseotdabwa.buyornot.core.ui.crop.EDIT_RESULT_KEY
 import com.sseotdabwa.buyornot.core.ui.crop.EDIT_RESULT_SKIPPED
+import com.sseotdabwa.buyornot.core.ui.crop.EDIT_RESULT_SPEC_KEY
+import com.sseotdabwa.buyornot.core.ui.crop.decodeEditSpecArg
 import com.sseotdabwa.buyornot.core.ui.crop.navigateToEdit
 import com.sseotdabwa.buyornot.feature.upload.ui.UploadIntent
 import com.sseotdabwa.buyornot.feature.upload.ui.UploadViewModel
@@ -38,18 +40,22 @@ fun NavGraphBuilder.uploadScreen(
 
         LaunchedEffect(editResult) {
             val result = editResult ?: return@LaunchedEffect
+            val specArg = backStackEntry.savedStateHandle.get<String>(EDIT_RESULT_SPEC_KEY)
             backStackEntry.savedStateHandle.remove<String>(EDIT_RESULT_KEY)
+            backStackEntry.savedStateHandle.remove<String>(EDIT_RESULT_SPEC_KEY)
             if (result == EDIT_RESULT_SKIPPED) {
                 viewModel.handleIntent(UploadIntent.CropSkipped)
             } else {
-                viewModel.handleIntent(UploadIntent.CropConfirmed(Uri.parse(result)))
+                viewModel.handleIntent(
+                    UploadIntent.CropConfirmed(Uri.parse(result), decodeEditSpecArg(specArg)),
+                )
             }
         }
 
         UploadRouteComposable(
             onNavigateBack = onNavigateBack,
             onNavigateToHomeReview = onNavigateToHomeReview,
-            onNavigateToCrop = { uri -> navController.navigateToEdit(uri) },
+            onNavigateToCrop = { uri, editSpec -> navController.navigateToEdit(uri, editSpec) },
             viewModel = viewModel,
         )
     }

--- a/feature/upload/src/main/java/com/sseotdabwa/buyornot/feature/upload/ui/UploadContract.kt
+++ b/feature/upload/src/main/java/com/sseotdabwa/buyornot/feature/upload/ui/UploadContract.kt
@@ -3,11 +3,13 @@ package com.sseotdabwa.buyornot.feature.upload.ui
 import android.content.Context
 import android.net.Uri
 import androidx.compose.ui.text.input.TextFieldValue
+import com.sseotdabwa.buyornot.core.ui.crop.state.EditSpec
 import com.sseotdabwa.buyornot.domain.model.FeedCategory
 
 data class ImageEntry(
     val originalUri: Uri,
     val displayUri: Uri,
+    val editSpec: EditSpec = EditSpec(),
 )
 
 data class UploadUiState(
@@ -80,6 +82,7 @@ sealed interface UploadIntent {
 
     data class CropConfirmed(
         val croppedUri: Uri,
+        val editSpec: EditSpec,
     ) : UploadIntent
 
     data object CropSkipped : UploadIntent
@@ -118,6 +121,7 @@ sealed interface UploadSideEffect {
 
     data class LaunchCrop(
         val uri: Uri,
+        val editSpec: EditSpec = EditSpec(),
     ) : UploadSideEffect
 
     data object NavigateBack : UploadSideEffect

--- a/feature/upload/src/main/java/com/sseotdabwa/buyornot/feature/upload/ui/UploadScreen.kt
+++ b/feature/upload/src/main/java/com/sseotdabwa/buyornot/feature/upload/ui/UploadScreen.kt
@@ -50,6 +50,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Paint
 import androidx.compose.ui.graphics.Path
@@ -238,6 +240,11 @@ fun UploadScreen(
 ) {
     val decimalFormat = remember { DecimalFormat("#,###") }
     val scrollState = rememberScrollState()
+    val contentFocusRequester = remember { FocusRequester() }
+
+    LaunchedEffect(Unit) {
+        contentFocusRequester.requestFocus()
+    }
 
     val isImeVisible = WindowInsets.ime.getBottom(LocalDensity.current) > 0
 
@@ -324,6 +331,7 @@ fun UploadScreen(
                 onTitleChange = { onIntent(UploadIntent.UpdateTitle(it)) },
                 content = uiState.content,
                 onContentChange = { onIntent(UploadIntent.UpdateContent(it)) },
+                contentFocusRequester = contentFocusRequester,
             )
 
             Spacer(modifier = Modifier.height(10.dp))
@@ -584,6 +592,7 @@ private fun ContentInputField(
     onTitleChange: (String) -> Unit,
     content: String,
     onContentChange: (String) -> Unit,
+    contentFocusRequester: FocusRequester,
 ) {
     Column(
         modifier = Modifier.fillMaxWidth(),
@@ -617,7 +626,8 @@ private fun ContentInputField(
             modifier =
                 Modifier
                     .fillMaxWidth()
-                    .heightIn(min = 84.dp),
+                    .heightIn(min = 84.dp)
+                    .focusRequester(contentFocusRequester),
             textStyle =
                 BuyOrNotTheme.typography.paragraphP2Medium.copy(
                     color = BuyOrNotTheme.colors.gray950,

--- a/feature/upload/src/main/java/com/sseotdabwa/buyornot/feature/upload/ui/UploadScreen.kt
+++ b/feature/upload/src/main/java/com/sseotdabwa/buyornot/feature/upload/ui/UploadScreen.kt
@@ -45,6 +45,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -242,9 +243,15 @@ fun UploadScreen(
     val decimalFormat = remember { DecimalFormat("#,###") }
     val scrollState = rememberScrollState()
     val contentFocusRequester = remember { FocusRequester() }
+    // 최초 진입 시에만 키패드를 띄운다. 업로드 -> 편집 -> 업로드 복귀 흐름에서는
+    // 컴포지션이 재생성되더라도 rememberSaveable 플래그가 유지되어 다시 포커스하지 않는다.
+    var hasRequestedInitialFocus by rememberSaveable { mutableStateOf(false) }
 
     LaunchedEffect(Unit) {
-        contentFocusRequester.requestFocus()
+        if (!hasRequestedInitialFocus) {
+            contentFocusRequester.requestFocus()
+            hasRequestedInitialFocus = true
+        }
     }
 
     val isImeVisible = WindowInsets.ime.getBottom(LocalDensity.current) > 0

--- a/feature/upload/src/main/java/com/sseotdabwa/buyornot/feature/upload/ui/UploadScreen.kt
+++ b/feature/upload/src/main/java/com/sseotdabwa/buyornot/feature/upload/ui/UploadScreen.kt
@@ -86,6 +86,7 @@ import com.sseotdabwa.buyornot.core.designsystem.icon.BuyOrNotIcons
 import com.sseotdabwa.buyornot.core.designsystem.icon.asImageVector
 import com.sseotdabwa.buyornot.core.designsystem.shape.BubbleShape
 import com.sseotdabwa.buyornot.core.designsystem.theme.BuyOrNotTheme
+import com.sseotdabwa.buyornot.core.ui.crop.state.EditSpec
 import com.sseotdabwa.buyornot.core.ui.snackbar.LocalSnackbarState
 import java.text.DecimalFormat
 
@@ -94,7 +95,7 @@ fun UploadRoute(
     modifier: Modifier = Modifier,
     onNavigateBack: () -> Unit = {},
     onNavigateToHomeReview: () -> Unit = {},
-    onNavigateToCrop: (Uri) -> Unit = {},
+    onNavigateToCrop: (Uri, EditSpec) -> Unit = { _, _ -> },
     viewModel: UploadViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -107,7 +108,7 @@ fun UploadRoute(
                 is UploadSideEffect.ShowSnackbar -> snackbarState.show(sideEffect.message)
                 is UploadSideEffect.NavigateBack -> onNavigateBack()
                 is UploadSideEffect.NavigateToHomeReview -> onNavigateToHomeReview()
-                is UploadSideEffect.LaunchCrop -> onNavigateToCrop(sideEffect.uri)
+                is UploadSideEffect.LaunchCrop -> onNavigateToCrop(sideEffect.uri, sideEffect.editSpec)
             }
         }
     }

--- a/feature/upload/src/main/java/com/sseotdabwa/buyornot/feature/upload/ui/UploadViewModel.kt
+++ b/feature/upload/src/main/java/com/sseotdabwa/buyornot/feature/upload/ui/UploadViewModel.kt
@@ -9,6 +9,7 @@ import com.sseotdabwa.buyornot.core.analytics.Analytics
 import com.sseotdabwa.buyornot.core.analytics.AnalyticsEvent
 import com.sseotdabwa.buyornot.core.common.util.runCatchingCancellable
 import com.sseotdabwa.buyornot.core.ui.base.BaseViewModel
+import com.sseotdabwa.buyornot.core.ui.crop.state.EditSpec
 import com.sseotdabwa.buyornot.domain.model.FeedImage
 import com.sseotdabwa.buyornot.domain.model.UserType
 import com.sseotdabwa.buyornot.domain.repository.FeedRepository
@@ -66,7 +67,7 @@ class UploadViewModel @Inject constructor(
                 }
             }
             is UploadIntent.StartCropQueue -> startCropQueue(intent.uris)
-            is UploadIntent.CropConfirmed -> onCropConfirmed(intent.croppedUri)
+            is UploadIntent.CropConfirmed -> onCropConfirmed(intent.croppedUri, intent.editSpec)
             is UploadIntent.CropSkipped -> onCropSkipped()
             is UploadIntent.StartReCrop -> startReCrop(intent.index)
             is UploadIntent.RemoveImage ->
@@ -114,7 +115,10 @@ class UploadViewModel @Inject constructor(
         sendSideEffect(UploadSideEffect.LaunchCrop(first))
     }
 
-    private fun onCropConfirmed(croppedUri: Uri) {
+    private fun onCropConfirmed(
+        croppedUri: Uri,
+        editSpec: EditSpec,
+    ) {
         val state = currentState
         if (state.recropIndex != null) {
             val idx = state.recropIndex
@@ -125,12 +129,12 @@ class UploadViewModel @Inject constructor(
             val original = state.selectedImages[idx].originalUri
             val updated =
                 state.selectedImages.toMutableList().apply {
-                    set(idx, ImageEntry(originalUri = original, displayUri = croppedUri))
+                    set(idx, ImageEntry(originalUri = original, displayUri = croppedUri, editSpec = editSpec))
                 }
             updateState { it.copy(selectedImages = updated, recropIndex = null, currentCropOriginal = null) }
         } else {
             val original = state.currentCropOriginal ?: return
-            val newEntry = ImageEntry(originalUri = original, displayUri = croppedUri)
+            val newEntry = ImageEntry(originalUri = original, displayUri = croppedUri, editSpec = editSpec)
             updateState { it.copy(selectedImages = it.selectedImages + newEntry) }
             advanceCropQueue()
         }
@@ -143,7 +147,7 @@ class UploadViewModel @Inject constructor(
             return
         }
         val original = state.currentCropOriginal ?: return
-        val newEntry = ImageEntry(originalUri = original, displayUri = original)
+        val newEntry = ImageEntry(originalUri = original, displayUri = original, editSpec = EditSpec())
         updateState { it.copy(selectedImages = it.selectedImages + newEntry) }
         advanceCropQueue()
     }
@@ -162,9 +166,9 @@ class UploadViewModel @Inject constructor(
     private fun startReCrop(index: Int) {
         val images = currentState.selectedImages
         if (index !in images.indices) return
-        val source = images[index].displayUri
-        updateState { it.copy(recropIndex = index, currentCropOriginal = source) }
-        sendSideEffect(UploadSideEffect.LaunchCrop(source))
+        val entry = images[index]
+        updateState { it.copy(recropIndex = index, currentCropOriginal = entry.originalUri) }
+        sendSideEffect(UploadSideEffect.LaunchCrop(entry.originalUri, entry.editSpec))
     }
 
     private fun submitFeed(context: Context) {

--- a/feature/upload/src/main/java/com/sseotdabwa/buyornot/feature/upload/ui/UploadViewModel.kt
+++ b/feature/upload/src/main/java/com/sseotdabwa/buyornot/feature/upload/ui/UploadViewModel.kt
@@ -162,9 +162,9 @@ class UploadViewModel @Inject constructor(
     private fun startReCrop(index: Int) {
         val images = currentState.selectedImages
         if (index !in images.indices) return
-        val original = images[index].originalUri
-        updateState { it.copy(recropIndex = index, currentCropOriginal = original) }
-        sendSideEffect(UploadSideEffect.LaunchCrop(original))
+        val source = images[index].displayUri
+        updateState { it.copy(recropIndex = index, currentCropOriginal = source) }
+        sendSideEffect(UploadSideEffect.LaunchCrop(source))
     }
 
     private fun submitFeed(context: Context) {


### PR DESCRIPTION
## 🛠 Related issue
closed #116

어떤 변경사항이 있었나요?
- [x] 🐞 BugFix Something isn't working
- [x] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [x] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (Junit, etc.)

## ✅ CheckPoint
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 컨벤션에 맞게 작성했습니다. (필수)
- [x] merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕) (필수)
- [x] Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다. (필수)
- [x] BugFix의 경우, 버그의 원인을 파악하였습니다. (선택)

## ✏️ Work Description

https://github.com/user-attachments/assets/e52ce4ec-9513-480a-8602-c7771db63271

이미지 크롭/편집 플로우를 개선했습니다.

- **재편집 시 이전 편집 상태 복원**: `SelectedImagePreview` 재진입 시 원본(originalUri)을 기준으로 직전 `EditSpec`(회전·자르기 영역)을 복원합니다. 자르기는 직전 영역이 선택된 상태로, 회전은 직전 각도에서 누적되며, 비파괴 편집이라 반복 재크롭에도 화질 저하가 없습니다.
- **사진 재선택 시 편집본 기준 편집**: 이미 편집한 사진을 다시 선택했을 때 원본이 아닌 편집된 결과를 기준으로 이어서 편집되도록 수정했습니다.
- **업로드 화면 진입 시 내용 필드 포커스**: 진입과 동시에 내용 입력 필드에 포커스를 줘 키패드가 올라오도록 했습니다.
- **이미지 뷰어 X 버튼 위치 수정**: 이미지가 상단 Close(X) 버튼을 가리던 문제를 해결해 버튼이 이미지 위에 표시되도록 했습니다.
- **CropOverlay 최대 영역 = 이미지 영역 정렬**: 코너 dot indicator가 잘리지 않도록 둔 이미지 inset(12.dp)을 imageBounds 계산에도 반영해, 크롭 오버레이의 최대 영역이 실제 표시 이미지 영역과 일치하도록 했습니다.

## 😅 Uncompleted Tasks
- N/A

## 📢 To Reviewers
- 핵심 변경은 크롭 편집 상태(`EditSpec`)를 네비게이션을 통해 왕복시키는 부분입니다. `EditSpec`은 경량 문자열 코덱(`EditNavigation.encodeToArg`/`decodeEditSpecArg`)으로 직렬화되어 `EditRoute` 인자 및 결과(`savedStateHandle`)로 오갑니다.
- 편집은 항상 originalUri 기준으로 동작하고, displayUri는 매 확정 시 `원본 + 최신 EditSpec`으로 재생성됩니다(비파괴).
- 빌드(`:core:ui`, `:feature:upload` 컴파일)는 통과했으나, 재크롭 상태 복원/오버레이 정렬 등 런타임 UI 동작은 기기 확인이 필요합니다.

## 📃 RCA 룰
- R: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
- C: 웬만하면 반영해 주세요. (Comment)
- A: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
