### PR TITLE
feat/#122: Header(TopBar) 디자인 정합 및 back-done variant 추가

### DIFF
--- a/core/designsystem/src/main/java/com/sseotdabwa/buyornot/core/designsystem/components/TopBar.kt
+++ b/core/designsystem/src/main/java/com/sseotdabwa/buyornot/core/designsystem/components/TopBar.kt
@@ -116,7 +116,41 @@ fun BackTopBarWithTitle(
 }
 
 /**
- * 3. 홈 화면용 TopBar (로고 + 알림 + 프로필)
+ * 3. 뒤로가기 + 완료 버튼 TopBar (back-done)
+ */
+@Composable
+fun BackTopBarWithDone(
+    onBackClick: () -> Unit,
+    onDoneClick: () -> Unit,
+) {
+    BaseTopBar(
+        navigationIcon = {
+            ClickableIcon(
+                imageVector = BuyOrNotIcons.ArrowLeft.asImageVector(),
+                contentDescription = "Back",
+                onClick = onBackClick,
+            )
+        },
+        actions = {
+            TextButton(
+                onClick = onDoneClick,
+                colors =
+                    ButtonDefaults.textButtonColors(
+                        contentColor = BuyOrNotTheme.colors.gray950,
+                    ),
+                contentPadding = PaddingValues(0.dp),
+            ) {
+                Text(
+                    text = "완료",
+                    style = BuyOrNotTheme.typography.subTitleS2SemiBold,
+                )
+            }
+        },
+    )
+}
+
+/**
+ * 4. 홈 화면용 TopBar (로고 + 알림 + 프로필)
  */
 @Composable
 fun HomeTopBar(
@@ -138,7 +172,7 @@ fun HomeTopBar(
                 imageVector = BuyOrNotIcons.NotificationFilled.asImageVector(),
                 contentDescription = "Notification",
                 onClick = onNotificationClick,
-                tint = BuyOrNotTheme.colors.gray500,
+                tint = BuyOrNotTheme.colors.gray600,
                 alignment = Alignment.CenterEnd,
             )
 
@@ -148,7 +182,7 @@ fun HomeTopBar(
                 imageVector = BuyOrNotIcons.Profile.asImageVector(),
                 contentDescription = "Profile",
                 onClick = onProfileClick,
-                tint = BuyOrNotTheme.colors.gray500,
+                tint = BuyOrNotTheme.colors.gray600,
                 alignment = Alignment.CenterEnd,
             )
         },
@@ -156,7 +190,7 @@ fun HomeTopBar(
 }
 
 /**
- * 4. 게스트/로그인 유도용 TopBar (로고 + 로그인 버튼)
+ * 5. 게스트/로그인 유도용 TopBar (로고 + 로그인 버튼)
  */
 @Composable
 fun GuestTopBar(onLoginClick: () -> Unit) {
@@ -175,7 +209,7 @@ fun GuestTopBar(onLoginClick: () -> Unit) {
                 colors =
                     ButtonDefaults.buttonColors(
                         containerColor = BuyOrNotTheme.colors.gray0,
-                        contentColor = BuyOrNotTheme.colors.gray700,
+                        contentColor = BuyOrNotTheme.colors.gray800,
                     ),
                 border =
                     BorderStroke(
@@ -184,7 +218,7 @@ fun GuestTopBar(onLoginClick: () -> Unit) {
                     ),
                 contentPadding =
                     PaddingValues(
-                        horizontal = 10.dp,
+                        horizontal = 12.dp,
                         vertical = 12.dp,
                     ),
             ) {
@@ -214,6 +248,17 @@ private fun BackTopBarWithTitlePreview() {
         BackTopBarWithTitle(
             title = "투표 피드",
             onBackClick = {},
+        )
+    }
+}
+
+@Preview(name = "BackTopBarWithDone", showBackground = true)
+@Composable
+private fun BackTopBarWithDonePreview() {
+    BuyOrNotTheme {
+        BackTopBarWithDone(
+            onBackClick = {},
+            onDoneClick = {},
         )
     }
 }


### PR DESCRIPTION
## 🛠 Related issue
[//]: # (해당하는 이슈 번호 달아주기)
closed #122

어떤 변경사항이 있었나요?
- [ ] 🐞 BugFix Something isn't working
- [x] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [x] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (Junit, etc.)

## ✅ CheckPoint
[//]: # (PR 요구사항 확인)
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 컨벤션에 맞게 작성했습니다. (필수)
- [x] merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕) (필수)
- [ ] Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다. (필수)
- [ ] BugFix의 경우, 버그의 원인을 파악하였습니다. (선택)

## ✏️ Work Description
[//]: # (작업 내용 간단 소개)

<img width="411" height="545" alt="image" src="https://github.com/user-attachments/assets/088a2f3d-3844-469b-a060-2f5bc6a0a6d5" />

- Figma Top Navigation 스펙(node 928:2600)과 `TopBar.kt`를 대조해 헤더를 정합했습니다.
- **back-done variant 신설**: `BackTopBarWithDone(onBackClick, onDoneClick)` — 뒤로가기 + "완료"(`subTitleS2SemiBold`, `gray950`, 우측). Preview 포함
- **GuestTopBar 로그인 버튼**: 텍스트 색 `gray700`→`gray800`(#565D6D), 좌우 패딩 `10`→`12`(Figma p-12)
- **HomeTopBar 아이콘 tint**: 알림·프로필 `gray500`→`gray600`(#B1B3BB)

## 😅 Uncompleted Tasks
[//]: # (없다면 N/A)
- [ ] 상단 top padding(10dp) 유지/제거 — 디자인 의도 확인 후 반영 예정
- [ ] 아이콘 20×20 / 터치영역 40×40 스펙 정합 여부 확인 예정

## 📢 To Reviewers
[//]: # (reviewer가 알면 좋은 내용들)
- 5개 variant(Back / Pagetitle / back-done / Home(Logout) / Guest(Login)) ↔ Figma 매핑 기준으로 정리했습니다.
- 컬러/타이포는 프로젝트 토큰 hex 기준으로 대조: `gray800`=#565D6D, `gray600`=#B1B3BB, `gray950`=#2A3038.
- "완료"는 문자열 리소스 없이 리터럴로 두었습니다. 공용 문자열화가 필요하면 알려주세요.

## 📃 RCA 룰
- R: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
- C: 웬만하면 반영해 주세요. (Comment)
- A: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 뒤로가기와 완료 버튼을 함께 제공하는 상단 바를 추가했습니다.
  * 완료 버튼 클릭 동작을 설정할 수 있습니다.

* **개선**
  * 홈 화면의 알림 및 프로필 아이콘 색상을 조정했습니다.
  * 비회원 화면의 로그인 버튼 색상과 여백을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->