### PR TITLE
feat/#124: Title Bold T5~T8 타이포 추가

### DIFF
--- a/core/designsystem/src/main/java/com/sseotdabwa/buyornot/core/designsystem/theme/ThemePreview.kt
+++ b/core/designsystem/src/main/java/com/sseotdabwa/buyornot/core/designsystem/theme/ThemePreview.kt
@@ -166,6 +166,10 @@ private fun TypographyCatalogPreview() {
                 TypographyItem("titleT2Bold", BuyOrNotTheme.typography.titleT2Bold)
                 TypographyItem("titleT3Bold", BuyOrNotTheme.typography.titleT3Bold)
                 TypographyItem("titleT4Bold", BuyOrNotTheme.typography.titleT4Bold)
+                TypographyItem("titleT5Bold", BuyOrNotTheme.typography.titleT5Bold)
+                TypographyItem("titleT6Bold", BuyOrNotTheme.typography.titleT6Bold)
+                TypographyItem("titleT7Bold", BuyOrNotTheme.typography.titleT7Bold)
+                TypographyItem("titleT8Bold", BuyOrNotTheme.typography.titleT8Bold)
             }
 
             // SubTitle

--- a/core/designsystem/src/main/java/com/sseotdabwa/buyornot/core/designsystem/theme/Typography.kt
+++ b/core/designsystem/src/main/java/com/sseotdabwa/buyornot/core/designsystem/theme/Typography.kt
@@ -101,6 +101,30 @@ internal val Typography =
                 fontSize = 14.sp,
                 lineHeight = (14 * 1.25f).sp,
             ),
+        titleT5Bold =
+            baseTextStyle.copy(
+                fontWeight = FontWeight.Bold,
+                fontSize = 13.sp,
+                lineHeight = (13 * 1.25f).sp,
+            ),
+        titleT6Bold =
+            baseTextStyle.copy(
+                fontWeight = FontWeight.Bold,
+                fontSize = 12.sp,
+                lineHeight = (12 * 1.25f).sp,
+            ),
+        titleT7Bold =
+            baseTextStyle.copy(
+                fontWeight = FontWeight.Bold,
+                fontSize = 11.sp,
+                lineHeight = (11 * 1.25f).sp,
+            ),
+        titleT8Bold =
+            baseTextStyle.copy(
+                fontWeight = FontWeight.Bold,
+                fontSize = 10.sp,
+                lineHeight = (10 * 1.25f).sp,
+            ),
         // Sub Title
         subTitleS1SemiBold =
             baseTextStyle.copy(
@@ -276,6 +300,10 @@ data class BuyOrNotTypography(
     val titleT2Bold: TextStyle,
     val titleT3Bold: TextStyle,
     val titleT4Bold: TextStyle,
+    val titleT5Bold: TextStyle,
+    val titleT6Bold: TextStyle,
+    val titleT7Bold: TextStyle,
+    val titleT8Bold: TextStyle,
     val subTitleS1SemiBold: TextStyle,
     val subTitleS2SemiBold: TextStyle,
     val subTitleS3SemiBold: TextStyle,


### PR DESCRIPTION
## 🛠 Related issue
[//]: # (해당하는 이슈 번호 달아주기)
closed #124

어떤 변경사항이 있었나요?
- [ ] 🐞 BugFix Something isn't working
- [x] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [x] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (Junit, etc.)

## ✅ CheckPoint
[//]: # (PR 요구사항 확인)
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 컨벤션에 맞게 작성했습니다. (필수)
- [x] merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕) (필수)
- [ ] Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다. (필수)
- [ ] BugFix의 경우, 버그의 원인을 파악하였습니다. (선택)

## ✏️ Work Description
[//]: # (작업 내용 간단 소개)
- Figma Typography 스펙(node 438:6521)과 `Typography.kt`를 대조해 누락된 **Title Bold** 스케일을 추가했습니다.
- 추가: `titleT5Bold`(13) / `titleT6Bold`(12) / `titleT7Bold`(11) / `titleT8Bold`(10) — 모두 `FontWeight.Bold`, lineHeight 125%(×1.25)
- `BuyOrNotTypography` data class와 `ThemePreview` 프리뷰에도 반영

## 😅 Uncompleted Tasks
[//]: # (없다면 N/A)
- [x] N/A

## 📢 To Reviewers
[//]: # (reviewer가 알면 좋은 내용들)
- Bold 계열 대조 결과 Display·Heading·Title(T1~T4)은 이미 스펙과 일치했고, 누락분(T5~T8)만 추가했습니다.
- 13sp에는 기존 `subTitleS5SemiBold`(SemiBold)만 있어 weight가 다른 `titleT5Bold`(Bold)를 별도로 추가했습니다.

## 📃 RCA 룰
- R: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
- C: 웬만하면 반영해 주세요. (Comment)
- A: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
