### PR TITLE
feat/#123: 안 읽은 알림 수 배지 및 unread-count API 연동

### DIFF
--- a/core/data/src/main/java/com/sseotdabwa/buyornot/core/data/repository/NotificationRepositoryImpl.kt
+++ b/core/data/src/main/java/com/sseotdabwa/buyornot/core/data/repository/NotificationRepositoryImpl.kt
@@ -18,6 +18,8 @@ class NotificationRepositoryImpl @Inject constructor(
         notificationApiService.markAsRead(notificationId).getOrThrow()
     }
 
+    override suspend fun getUnreadCount(): Int = notificationApiService.getUnreadCount().getOrThrow().unreadCount
+
     private fun NotificationResponse.toDomain(): Notification =
         Notification(
             notificationId = notificationId,

--- a/core/designsystem/src/main/java/com/sseotdabwa/buyornot/core/designsystem/components/NotificationBadge.kt
+++ b/core/designsystem/src/main/java/com/sseotdabwa/buyornot/core/designsystem/components/NotificationBadge.kt
@@ -1,0 +1,106 @@
+package com.sseotdabwa.buyornot.core.designsystem.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.sseotdabwa.buyornot.core.designsystem.theme.BuyOrNotTheme
+
+private object NotificationBadgeDefaults {
+    val NumberMinWidth = 18.dp
+    val NumberHorizontalPadding = 4.dp
+    val NumberVerticalPadding = 2.dp
+    val DotSize = 5.dp
+    const val MAX_COUNT = 99
+}
+
+/**
+ * 안 읽은 알림 수를 표시하는 number 배지.
+ *
+ * 배경 red100(#FF3830), 흰색 Bold 10 텍스트, pill 형태(완전 라운드), 최소 너비 18dp,
+ * 자릿수가 늘어나면 우측으로 확장됩니다. count가 99를 초과하면 "99+"로 표시합니다.
+ *
+ * count == 0인 경우 호출부에서 노출 여부를 결정합니다(이 컴포저블은 값과 무관하게 항상 렌더링).
+ *
+ * @param count 표시할 안 읽은 알림 수 (호출부에서 count > 0 일 때만 노출 권장)
+ */
+@Composable
+fun NotificationNumberBadge(
+    count: Int,
+    modifier: Modifier = Modifier,
+) {
+    val text = if (count > NotificationBadgeDefaults.MAX_COUNT) "${NotificationBadgeDefaults.MAX_COUNT}+" else count.toString()
+    Box(
+        modifier =
+            modifier
+                .defaultMinSize(minWidth = NotificationBadgeDefaults.NumberMinWidth)
+                .clip(CircleShape)
+                .background(BuyOrNotTheme.colors.red100)
+                .padding(
+                    horizontal = NotificationBadgeDefaults.NumberHorizontalPadding,
+                    vertical = NotificationBadgeDefaults.NumberVerticalPadding,
+                ),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = text,
+            style = BuyOrNotTheme.typography.titleT7Bold,
+            color = BuyOrNotTheme.colors.gray0,
+        )
+    }
+}
+
+/**
+ * 5dp red 원형 점 배지.
+ */
+@Composable
+fun NotificationDotBadge(modifier: Modifier = Modifier) {
+    Box(
+        modifier =
+            modifier
+                .size(NotificationBadgeDefaults.DotSize)
+                .clip(CircleShape)
+                .background(BuyOrNotTheme.colors.red100),
+    )
+}
+
+@Preview(name = "NotificationNumberBadge - 1", showBackground = true)
+@Composable
+private fun NotificationNumberBadgeSinglePreview() {
+    BuyOrNotTheme {
+        NotificationNumberBadge(count = 1)
+    }
+}
+
+@Preview(name = "NotificationNumberBadge - 99", showBackground = true)
+@Composable
+private fun NotificationNumberBadgeMaxPreview() {
+    BuyOrNotTheme {
+        NotificationNumberBadge(count = 99)
+    }
+}
+
+@Preview(name = "NotificationNumberBadge - 100 (99+)", showBackground = true)
+@Composable
+private fun NotificationNumberBadgeOverflowPreview() {
+    BuyOrNotTheme {
+        NotificationNumberBadge(count = 100)
+    }
+}
+
+@Preview(name = "NotificationDotBadge", showBackground = true)
+@Composable
+private fun NotificationDotBadgePreview() {
+    BuyOrNotTheme {
+        NotificationDotBadge()
+    }
+}

--- a/core/designsystem/src/main/java/com/sseotdabwa/buyornot/core/designsystem/components/TopBar.kt
+++ b/core/designsystem/src/main/java/com/sseotdabwa/buyornot/core/designsystem/components/TopBar.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -157,6 +158,7 @@ fun HomeTopBar(
     onNotificationClick: () -> Unit,
     onProfileClick: () -> Unit,
     modifier: Modifier = Modifier,
+    unreadCount: Int = 0,
 ) {
     BaseTopBar(
         modifier = modifier,
@@ -168,13 +170,29 @@ fun HomeTopBar(
             )
         },
         actions = {
-            ClickableIcon(
-                imageVector = BuyOrNotIcons.NotificationFilled.asImageVector(),
-                contentDescription = "Notification",
-                onClick = onNotificationClick,
-                tint = BuyOrNotTheme.colors.gray600,
-                alignment = Alignment.CenterEnd,
-            )
+            // ClickableIcon이 유일한 클릭 대상(40dp 터치 영역)이며, 배지는 그 위에 얹힌
+            // 비상호작용 시각 오버레이입니다. 배지에는 pointerInput/clickable이 없어 탭을 소비하지 않습니다.
+            Box {
+                ClickableIcon(
+                    imageVector = BuyOrNotIcons.NotificationFilled.asImageVector(),
+                    contentDescription = "Notification",
+                    onClick = onNotificationClick,
+                    tint = BuyOrNotTheme.colors.gray600,
+                    alignment = Alignment.CenterEnd,
+                )
+
+                if (unreadCount > 0) {
+                    // Figma: 40dp 터치 영역의 우상단 모서리 기준으로 오른쪽 위로 살짝 튀어나오게 배치.
+                    // (badge 우상단 = 터치영역 우상단 + (x +6, y +3))
+                    NotificationNumberBadge(
+                        count = unreadCount,
+                        modifier =
+                            Modifier
+                                .align(Alignment.TopEnd)
+                                .offset(x = 6.dp, y = 3.dp),
+                    )
+                }
+            }
 
             Spacer(modifier = Modifier.width(TopBarDefaults.IconSpacing))
 
@@ -270,6 +288,7 @@ private fun HomeTopBarPreview() {
         HomeTopBar(
             onNotificationClick = {},
             onProfileClick = {},
+            unreadCount = 3,
         )
     }
 }

--- a/core/network/src/main/java/com/sseotdabwa/buyornot/core/network/api/NotificationApiService.kt
+++ b/core/network/src/main/java/com/sseotdabwa/buyornot/core/network/api/NotificationApiService.kt
@@ -2,6 +2,7 @@ package com.sseotdabwa.buyornot.core.network.api
 
 import com.sseotdabwa.buyornot.core.network.dto.response.BaseResponse
 import com.sseotdabwa.buyornot.core.network.dto.response.NotificationResponse
+import com.sseotdabwa.buyornot.core.network.dto.response.UnreadCountResponse
 import retrofit2.http.GET
 import retrofit2.http.PATCH
 import retrofit2.http.Path
@@ -17,4 +18,7 @@ interface NotificationApiService {
     suspend fun markAsRead(
         @Path("notificationId") notificationId: Long,
     ): BaseResponse<Unit>
+
+    @GET("/api/v1/notifications/unread-count")
+    suspend fun getUnreadCount(): BaseResponse<UnreadCountResponse>
 }

--- a/core/network/src/main/java/com/sseotdabwa/buyornot/core/network/dto/response/UnreadCountResponse.kt
+++ b/core/network/src/main/java/com/sseotdabwa/buyornot/core/network/dto/response/UnreadCountResponse.kt
@@ -1,0 +1,8 @@
+package com.sseotdabwa.buyornot.core.network.dto.response
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class UnreadCountResponse(
+    val unreadCount: Int,
+)

--- a/domain/src/main/java/com/sseotdabwa/buyornot/domain/repository/NotificationRepository.kt
+++ b/domain/src/main/java/com/sseotdabwa/buyornot/domain/repository/NotificationRepository.kt
@@ -6,4 +6,6 @@ interface NotificationRepository {
     suspend fun getNotifications(type: String?): List<Notification>
 
     suspend fun markAsRead(notificationId: Long)
+
+    suspend fun getUnreadCount(): Int
 }

--- a/feature/home/src/main/java/com/sseotdabwa/buyornot/feature/home/ui/HomeContract.kt
+++ b/feature/home/src/main/java/com/sseotdabwa/buyornot/feature/home/ui/HomeContract.kt
@@ -84,6 +84,7 @@ data class HomeUiState(
     val blockingUserId: Long? = null,
     val showSortSheet: Boolean = false,
     val isTooltipDismissed: Boolean = false,
+    val unreadNotificationCount: Int = 0,
 )
 
 /**
@@ -120,6 +121,8 @@ sealed interface HomeIntent {
     ) : HomeIntent
 
     data object LoadFeeds : HomeIntent
+
+    data object RefreshUnreadCount : HomeIntent
 
     data object LoadNextPage : HomeIntent
 

--- a/feature/home/src/main/java/com/sseotdabwa/buyornot/feature/home/ui/HomeScreen.kt
+++ b/feature/home/src/main/java/com/sseotdabwa/buyornot/feature/home/ui/HomeScreen.kt
@@ -237,6 +237,7 @@ fun HomeScreen(
 @Composable
 private fun HomeTopBarSection(
     userType: UserType,
+    unreadNotificationCount: Int,
     onLoginClick: () -> Unit,
     onNotificationClick: () -> Unit,
     onProfileClick: () -> Unit,
@@ -247,6 +248,7 @@ private fun HomeTopBarSection(
             HomeTopBar(
                 onNotificationClick = onNotificationClick,
                 onProfileClick = onProfileClick,
+                unreadCount = unreadNotificationCount,
             )
         }
     }
@@ -371,6 +373,7 @@ private fun HomeFeedList(
     LifecycleEventEffect(Lifecycle.Event.ON_START) {
         enterTimeMs = System.currentTimeMillis()
         onIntent(HomeIntent.OnFeedScreenEntered(firstVisibleItemIndex = listState.firstVisibleItemIndex))
+        onIntent(HomeIntent.RefreshUnreadCount)
     }
     LifecycleEventEffect(Lifecycle.Event.ON_STOP) {
         onIntent(
@@ -561,6 +564,7 @@ private fun HomeFeedList(
                     ) {
                         HomeTopBarSection(
                             userType = uiState.userType,
+                            unreadNotificationCount = uiState.unreadNotificationCount,
                             onLoginClick = onLoginClick,
                             onNotificationClick = onNotificationClick,
                             onProfileClick = onProfileClick,

--- a/feature/home/src/main/java/com/sseotdabwa/buyornot/feature/home/ui/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/sseotdabwa/buyornot/feature/home/ui/HomeViewModel.kt
@@ -19,6 +19,7 @@ import com.sseotdabwa.buyornot.domain.repository.NotificationRepository
 import com.sseotdabwa.buyornot.domain.repository.UserPreferencesRepository
 import com.sseotdabwa.buyornot.domain.repository.UserRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -36,6 +37,7 @@ class HomeViewModel @Inject constructor(
 ) : BaseViewModel<HomeUiState, HomeIntent, HomeSideEffect>(HomeUiState()) {
     private var currentUserId: Long? = null
     private var isUserIdLoaded = false
+    private var unreadCountJob: Job? = null
 
     init {
         observeUserPreferences()
@@ -60,6 +62,7 @@ class HomeViewModel @Inject constructor(
                             loadUserIdAndRefreshFeeds()
                             loadUnreadCount()
                         } else {
+                            unreadCountJob?.cancel()
                             currentUserId = null
                             isUserIdLoaded = true
                             updateState { it.copy(selectedTab = HomeTab.FEED, unreadNotificationCount = 0) }
@@ -112,15 +115,21 @@ class HomeViewModel @Inject constructor(
     private fun loadUnreadCount() {
         if (uiState.value.userType != UserType.SOCIAL) return
 
-        viewModelScope.launch {
-            runCatchingCancellable {
-                notificationRepository.getUnreadCount()
-            }.onSuccess { count ->
-                updateState { it.copy(unreadNotificationCount = count) }
-            }.onFailure { e ->
-                Log.e("HomeViewModel", "Failed to load unread notification count", e)
+        // 겹치는 요청 시 이전 요청을 취소해 오래된 응답이 최신 값을 덮어쓰지 않도록 한다.
+        unreadCountJob?.cancel()
+        unreadCountJob =
+            viewModelScope.launch {
+                runCatchingCancellable {
+                    notificationRepository.getUnreadCount()
+                }.onSuccess { count ->
+                    // 로그아웃 등으로 세션이 바뀐 뒤 도착한 응답은 무시한다.
+                    if (uiState.value.userType == UserType.SOCIAL) {
+                        updateState { it.copy(unreadNotificationCount = count) }
+                    }
+                }.onFailure { e ->
+                    Log.e("HomeViewModel", "Failed to load unread notification count", e)
+                }
             }
-        }
     }
 
     override fun handleIntent(intent: HomeIntent) {

--- a/feature/home/src/main/java/com/sseotdabwa/buyornot/feature/home/ui/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/sseotdabwa/buyornot/feature/home/ui/HomeViewModel.kt
@@ -15,6 +15,7 @@ import com.sseotdabwa.buyornot.domain.model.FeedStatus
 import com.sseotdabwa.buyornot.domain.model.UserType
 import com.sseotdabwa.buyornot.domain.model.VoteChoice
 import com.sseotdabwa.buyornot.domain.repository.FeedRepository
+import com.sseotdabwa.buyornot.domain.repository.NotificationRepository
 import com.sseotdabwa.buyornot.domain.repository.UserPreferencesRepository
 import com.sseotdabwa.buyornot.domain.repository.UserRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -30,6 +31,7 @@ class HomeViewModel @Inject constructor(
     private val userPreferencesRepository: UserPreferencesRepository,
     private val feedRepository: FeedRepository,
     private val userRepository: UserRepository,
+    private val notificationRepository: NotificationRepository,
     private val analytics: Analytics,
 ) : BaseViewModel<HomeUiState, HomeIntent, HomeSideEffect>(HomeUiState()) {
     private var currentUserId: Long? = null
@@ -56,10 +58,11 @@ class HomeViewModel @Inject constructor(
                     if (lastUserType != userType) {
                         if (userType == UserType.SOCIAL) {
                             loadUserIdAndRefreshFeeds()
+                            loadUnreadCount()
                         } else {
                             currentUserId = null
                             isUserIdLoaded = true
-                            updateState { it.copy(selectedTab = HomeTab.FEED) }
+                            updateState { it.copy(selectedTab = HomeTab.FEED, unreadNotificationCount = 0) }
                             loadFeeds(tab = HomeTab.FEED)
                         }
                         lastUserType = userType
@@ -102,6 +105,24 @@ class HomeViewModel @Inject constructor(
         }
     }
 
+    /**
+     * 안 읽은 알림 수를 조회해 배지 상태에 반영한다.
+     * 로그인(SOCIAL) 상태에서만 호출하며, 실패 시 silent(이전 값 유지, UI 오류 없음).
+     */
+    private fun loadUnreadCount() {
+        if (uiState.value.userType != UserType.SOCIAL) return
+
+        viewModelScope.launch {
+            runCatchingCancellable {
+                notificationRepository.getUnreadCount()
+            }.onSuccess { count ->
+                updateState { it.copy(unreadNotificationCount = count) }
+            }.onFailure { e ->
+                Log.e("HomeViewModel", "Failed to load unread notification count", e)
+            }
+        }
+    }
+
     override fun handleIntent(intent: HomeIntent) {
         when (intent) {
             is HomeIntent.OnTabSelected -> handleTabSelection(intent.tab)
@@ -126,6 +147,7 @@ class HomeViewModel @Inject constructor(
                 }
             is HomeIntent.OnBlockConfirmed -> handleBlockConfirmed()
             is HomeIntent.LoadFeeds -> loadFeeds()
+            is HomeIntent.RefreshUnreadCount -> loadUnreadCount()
             is HomeIntent.LoadNextPage -> handleNextPage()
             is HomeIntent.Refresh -> handleRefresh()
             is HomeIntent.OnCategoryToggled -> handleCategoryToggled(intent.category)


### PR DESCRIPTION
## 🛠 Related issue
[//]: # (해당하는 이슈 번호 달아주기)
closed #123

어떤 변경사항이 있었나요?
- [ ] 🐞 BugFix Something isn't working
- [x] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [x] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (Junit, etc.)

## ✅ CheckPoint
[//]: # (PR 요구사항 확인)
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 컨벤션에 맞게 작성했습니다. (필수)
- [x] merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕) (필수)
- [ ] Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다. (필수)
- [ ] BugFix의 경우, 버그의 원인을 파악하였습니다. (선택)

## ✏️ Work Description
[//]: # (작업 내용 간단 소개)

<img width="540" height="1260" alt="image" src="https://github.com/user-attachments/assets/c1ed5385-96c0-42d6-a04b-2bfb34e6c107" />


- `GET /api/v1/notifications/unread-count` 연동: `UnreadCountResponse` DTO + `NotificationRepository.getUnreadCount(): Int`
- `NotificationBadge` 컴포넌트 추가 — number(red pill · 흰 titleT7Bold · min-width 18 · `99+` · 0이면 미노출) + dot(5dp) variant, Preview 포함
- `HomeTopBar` 알림 아이콘 **우상단에 배지 오버레이** — Figma 좌표 기준(터치영역 우상단 +6/+3 overhang). 터치 영역은 그대로 두고 배지는 **비상호작용 순수 오버레이**
- `HomeViewModel`: userType이 SOCIAL로 확정될 때 + 화면 복귀(ON_START)마다 unread-count 조회, 실패 silent, 로그아웃 시 배지 리셋

## 😅 Uncompleted Tasks
[//]: # (없다면 N/A)
- [x] N/A

## 📢 To Reviewers
[//]: # (reviewer가 알면 좋은 내용들)
- 배지는 알림 아이콘의 40dp 터치 영역을 변경하지 않는 시각 오버레이입니다(탭 소비 X).
- 배지 배경은 기존 테마 토큰 `red100`(#FF3830), 텍스트는 `titleT7Bold`(#124에서 추가) 재사용.
- 최초 진입 시 호출 안 되던 이슈 수정: userType flow가 비동기라 init 시점 동기 호출이 GUEST 가드에 막혔던 것을 SOCIAL 확정 분기에서 호출하도록 변경.
- dot variant는 컴포넌트로만 제공하고 이번 unread-count 연동엔 number만 사용.

## 📃 RCA 룰
- R: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
- C: 웬만하면 반영해 주세요. (Comment)
- A: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 홈 화면 알림 아이콘에 읽지 않은 알림 개수 배지를 표시합니다.
  - 읽지 않은 알림이 없으면 배지를 숨기고, 100개 이상은 `99+`로 표시합니다.
  - 홈 화면 진입 시 읽지 않은 알림 개수를 자동으로 갱신합니다.
  - 소셜 사용자 전환 시 알림 개수를 불러오며, 다른 사용자 유형에서는 배지를 초기화합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->