### PR TITLE
fix/#128: 홈 피드 페이지네이션 중복 feedId로 인한 LazyColumn 크래시 수정

### DIFF
--- a/feature/home/src/main/java/com/sseotdabwa/buyornot/feature/home/ui/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/sseotdabwa/buyornot/feature/home/ui/HomeViewModel.kt
@@ -268,7 +268,9 @@ class HomeViewModel @Inject constructor(
                         feed.toFeedItem(isOwner)
                     }
 
-                val newAllFeeds = currentState.allFeeds + newItems
+                // 커서 기반 페이지네이션에서 페이지 경계가 겹치면 동일 feedId가 중복될 수 있어
+                // LazyColumn 중복 key 크래시가 발생한다. id 기준으로 중복을 제거한다. (이슈 #128)
+                val newAllFeeds = (currentState.allFeeds + newItems).distinctBy { it.id }
 
                 updateState {
                     it.copy(
@@ -533,10 +535,13 @@ class HomeViewModel @Inject constructor(
                 }
             }.onSuccess { feedList ->
                 val newFeeds =
-                    feedList.feeds.map { feed ->
-                        val isOwner = currentUserId != null && feed.author.userId == currentUserId
-                        feed.toFeedItem(isOwner)
-                    }
+                    feedList.feeds
+                        .map { feed ->
+                            val isOwner = currentUserId != null && feed.author.userId == currentUserId
+                            feed.toFeedItem(isOwner)
+                        }
+                        // LazyColumn key 유일성 보장: 동일 feedId 중복 방지 (이슈 #128)
+                        .distinctBy { it.id }
                 updateState {
                     it.copy(
                         allFeeds = newFeeds,

--- a/feature/home/src/main/java/com/sseotdabwa/buyornot/feature/home/ui/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/sseotdabwa/buyornot/feature/home/ui/HomeViewModel.kt
@@ -580,10 +580,13 @@ class HomeViewModel @Inject constructor(
                 }
             }.onSuccess { feedList ->
                 val refreshedFeeds =
-                    feedList.feeds.map { feed ->
-                        val isOwner = currentUserId != null && feed.author.userId == currentUserId
-                        feed.toFeedItem(isOwner)
-                    }
+                    feedList.feeds
+                        .map { feed ->
+                            val isOwner = currentUserId != null && feed.author.userId == currentUserId
+                            feed.toFeedItem(isOwner)
+                        }
+                        // LazyColumn key 유일성 보장: 새로고침 응답의 중복 feedId 방지 (이슈 #128)
+                        .distinctBy { it.id }
                 updateState {
                     it.copy(
                         allFeeds = refreshedFeeds,

--- a/feature/home/src/main/java/com/sseotdabwa/buyornot/feature/home/ui/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/sseotdabwa/buyornot/feature/home/ui/HomeViewModel.kt
@@ -39,6 +39,11 @@ class HomeViewModel @Inject constructor(
     private var isUserIdLoaded = false
     private var unreadCountJob: Job? = null
 
+    // 피드 로딩 요청 세대. 새 로드/새로고침(탭·필터·카테고리 변경 포함) 시 증가시키고,
+    // 페이지네이션은 요청 시작 시점의 세대와 일치할 때만 결과를 병합해
+    // 진행 중이던 이전 페이지 응답이 최신 목록/커서를 덮어쓰지 않도록 한다. (PR #129 리뷰)
+    private var feedGeneration = 0
+
     init {
         observeUserPreferences()
         loadInitialData()
@@ -235,6 +240,7 @@ class HomeViewModel @Inject constructor(
     private fun handleNextPage() {
         if (currentState.isNextPageLoading || !currentState.hasNextPage) return
 
+        val requestGeneration = feedGeneration
         viewModelScope.launch {
             updateState { it.copy(isNextPageLoading = true) }
             val requestedTab = currentState.selectedTab
@@ -257,7 +263,9 @@ class HomeViewModel @Inject constructor(
                         )
                 }
             }.onSuccess { feedList ->
-                if (currentState.selectedTab != requestedTab) {
+                // 요청 중 새 로드/새로고침/필터·카테고리·탭 변경이 있었으면(세대 불일치)
+                // 오래된 페이지 병합과 hasNextPage/nextCursor 갱신을 건너뛴다. (PR #129 리뷰)
+                if (feedGeneration != requestGeneration) {
                     updateState { it.copy(isNextPageLoading = false) }
                     return@launch
                 }
@@ -505,6 +513,8 @@ class HomeViewModel @Inject constructor(
         tab: HomeTab? = null,
         clearFeeds: Boolean = true,
     ) {
+        // 새 로드 컨텍스트 시작 → 진행 중이던 페이지네이션 응답 무효화
+        feedGeneration++
         viewModelScope.launch {
             if (clearFeeds) {
                 updateState {
@@ -566,6 +576,8 @@ class HomeViewModel @Inject constructor(
     private fun handleRefresh() {
         if (currentState.isRefreshing) return
 
+        // 새로고침도 새 로드 컨텍스트 → 진행 중이던 페이지네이션 응답 무효화
+        feedGeneration++
         viewModelScope.launch {
             updateState { it.copy(isRefreshing = true, hasError = false) }
 


### PR DESCRIPTION
## 🛠 Related issue
closed #128

어떤 변경사항이 있었나요?
- [x] 🐞 BugFix Something isn't working
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [ ] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (Junit, etc.)

## ✅ CheckPoint
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 컨벤션에 맞게 작성했습니다. (필수)
- [x] merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕) (필수)
- [ ] Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다. (필수)
- [x] BugFix의 경우, 버그의 원인을 파악하였습니다. (선택)

## ✏️ Work Description
- 홈 피드 스크롤 중 `LazyColumn` 중복 key(`IllegalArgumentException: Key "104" was already used`)로 인한 크래시를 수정했습니다.
- 원인: 커서 기반 페이지네이션에서 페이지 경계가 겹칠 때 동일 `feedId`가 리스트에 중복 추가되어, `LazyColumn`의 key 유일성 제약을 위반했습니다.
- 다음 페이지 병합 시 `(currentState.allFeeds + newItems).distinctBy { it.id }`로 중복 feedId를 제거했습니다. (`HomeViewModel.handleNextPage`)
- 초기 로드 시에도 `distinctBy { it.id }`를 적용해 `allFeeds`의 id 유일성 불변식을 일관되게 보장했습니다. (`HomeViewModel.loadFeeds`)

## 😅 Uncompleted Tasks
- [x] N/A

## 📢 To Reviewers
- 근본 방어는 서버 커서 페이지네이션이 페이지 경계에서 중복 항목을 내려주지 않는 것이지만, 클라이언트에서 방어적으로 중복을 제거해 크래시를 막았습니다.
- 투표 낙관적 업데이트/롤백 경로는 `map` 변환이라 중복이 발생하지 않아 그대로 두었습니다.

## 📃 RCA 룰
- R: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
- C: 웬만하면 반영해 주세요. (Comment)
- A: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 피드 목록에서 중복 항목이 표시되지 않도록 개선했습니다.
  * 페이지를 추가로 불러오거나 탭·필터를 변경할 때 중복 피드가 자동으로 제거됩니다.
  * 목록 표시 중 발생할 수 있는 중복 항목 관련 오류를 방지했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->