### PR TITLE
feat/#132: 푸시 알림 탭 유입 로깅(push_opened) 추가

### DIFF
--- a/app/src/main/java/com/sseotdabwa/buyornot/MainActivity.kt
+++ b/app/src/main/java/com/sseotdabwa/buyornot/MainActivity.kt
@@ -70,14 +70,16 @@ class MainActivity : ComponentActivity() {
 
     /**
      * 알림 탭 유입을 로깅한다. 딥링크(feedId 필요)와 분리해야 feedId가 없는 마케팅 알림 탭도 잡힌다.
+     *
+     * 탭 판별은 서버 data 페이로드 키인 [FcmKeys.TYPE]의 존재로 한다. 앱이 심은 마커를 쓰면
+     * 백그라운드·종료 상태 탭(FCM이 launch Intent를 만드는 경로)이 전부 누락된다.
      */
     private fun handlePushOpened(intent: Intent?) {
-        if (intent == null || !intent.getBooleanExtra(FcmKeys.FROM_PUSH, false)) return
+        if (intent == null || !intent.hasExtra(FcmKeys.TYPE)) return
         val pushType = intent.getStringExtra(FcmKeys.TYPE) ?: FcmKeys.UNKNOWN_TYPE
         val feedId = intent.longExtraOrNull(FcmKeys.FEED_ID)
         val notificationId = intent.longExtraOrNull(FcmKeys.NOTIFICATION_ID)
         // 회전·프로세스 재생성으로 onCreate가 같은 Intent를 다시 받아도 중복 발행되지 않도록 마커를 소비한다.
-        intent.removeExtra(FcmKeys.FROM_PUSH)
         intent.removeExtra(FcmKeys.TYPE)
         setIntent(intent)
         if (BuildConfig.DEBUG) {

--- a/app/src/main/java/com/sseotdabwa/buyornot/MainActivity.kt
+++ b/app/src/main/java/com/sseotdabwa/buyornot/MainActivity.kt
@@ -10,6 +10,8 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.runtime.getValue
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.sseotdabwa.buyornot.core.analytics.Analytics
+import com.sseotdabwa.buyornot.core.analytics.AnalyticsEvent
 import com.sseotdabwa.buyornot.core.designsystem.theme.BuyOrNotTheme
 import com.sseotdabwa.buyornot.core.network.AuthEventBus
 import com.sseotdabwa.buyornot.notification.FcmKeys
@@ -23,10 +25,15 @@ class MainActivity : ComponentActivity() {
     @Inject
     lateinit var authEventBus: AuthEventBus
 
+    @Inject
+    lateinit var analytics: Analytics
+
     private val pendingFeedDeepLink = MutableStateFlow<PendingFeedDeepLink?>(null)
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        // 딥링크 처리가 feedId extra를 소비하므로 로깅을 먼저 수행한다.
+        handlePushOpened(intent)
         handleFeedDeepLink(intent)
         enableEdgeToEdge(
             statusBarStyle =
@@ -57,17 +64,38 @@ class MainActivity : ComponentActivity() {
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
         setIntent(intent)
+        handlePushOpened(intent)
         handleFeedDeepLink(intent)
+    }
+
+    /**
+     * 알림 탭 유입을 로깅한다. 딥링크(feedId 필요)와 분리해야 feedId가 없는 마케팅 알림 탭도 잡힌다.
+     */
+    private fun handlePushOpened(intent: Intent?) {
+        if (intent == null || !intent.getBooleanExtra(FcmKeys.FROM_PUSH, false)) return
+        val pushType = intent.getStringExtra(FcmKeys.TYPE) ?: FcmKeys.UNKNOWN_TYPE
+        val feedId = intent.longExtraOrNull(FcmKeys.FEED_ID)
+        val notificationId = intent.longExtraOrNull(FcmKeys.NOTIFICATION_ID)
+        // 회전·프로세스 재생성으로 onCreate가 같은 Intent를 다시 받아도 중복 발행되지 않도록 마커를 소비한다.
+        intent.removeExtra(FcmKeys.FROM_PUSH)
+        intent.removeExtra(FcmKeys.TYPE)
+        setIntent(intent)
+        if (BuildConfig.DEBUG) {
+            Log.d("FCM", "handlePushOpened - pushType=$pushType, feedId=$feedId, notificationId=$notificationId")
+        }
+        analytics.track(
+            AnalyticsEvent.PushOpened(
+                pushType = pushType,
+                feedId = feedId,
+                notificationId = notificationId,
+            ),
+        )
     }
 
     private fun handleFeedDeepLink(intent: Intent?) {
         if (intent == null || !intent.hasExtra(FcmKeys.FEED_ID)) return
-        val feedId =
-            intent.getStringExtra(FcmKeys.FEED_ID)?.toLongOrNull()
-                ?: intent.getLongExtra(FcmKeys.FEED_ID, -1L).takeIf { it != -1L }
-        val notificationId =
-            intent.getStringExtra(FcmKeys.NOTIFICATION_ID)?.toLongOrNull()
-                ?: intent.getLongExtra(FcmKeys.NOTIFICATION_ID, -1L).takeIf { it != -1L }
+        val feedId = intent.longExtraOrNull(FcmKeys.FEED_ID)
+        val notificationId = intent.longExtraOrNull(FcmKeys.NOTIFICATION_ID)
         intent.removeExtra(FcmKeys.FEED_ID)
         intent.removeExtra(FcmKeys.NOTIFICATION_ID)
         setIntent(intent)
@@ -80,6 +108,11 @@ class MainActivity : ComponentActivity() {
         }
     }
 }
+
+/** 서버가 Long/String 중 무엇으로 보내도 읽히도록 두 형태를 모두 시도한다. */
+private fun Intent.longExtraOrNull(key: String): Long? =
+    getStringExtra(key)?.toLongOrNull()
+        ?: getLongExtra(key, -1L).takeIf { it != -1L }
 
 data class PendingFeedDeepLink(
     val feedId: Long,

--- a/app/src/main/java/com/sseotdabwa/buyornot/notification/BuyOrNotMessagingService.kt
+++ b/app/src/main/java/com/sseotdabwa/buyornot/notification/BuyOrNotMessagingService.kt
@@ -58,6 +58,7 @@ class BuyOrNotMessagingService : FirebaseMessagingService() {
         }
 
         showFeedNotification(
+            type = type,
             feedId = feedId,
             notificationId = notificationId,
             title = message.notification?.title ?: DEFAULT_TITLE,
@@ -66,6 +67,7 @@ class BuyOrNotMessagingService : FirebaseMessagingService() {
     }
 
     private fun showFeedNotification(
+        type: String?,
         feedId: Long?,
         notificationId: Long?,
         title: String,
@@ -73,10 +75,13 @@ class BuyOrNotMessagingService : FirebaseMessagingService() {
     ) {
         createNotificationChannel()
 
-        // 마케팅(feedId·notificationId 없음)은 딥링크 없이 앱만 열리도록 extra를 심지 않는다.
+        // 딥링크용 feedId/notificationId는 있을 때만 심는다(마케팅 알림은 없음).
+        // 반면 푸시 마커와 type은 유입 로깅(push_opened)에 필요하므로 마케팅 알림에도 항상 심는다.
         val intent =
             Intent(this, MainActivity::class.java).apply {
                 flags = Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP
+                putExtra(FcmKeys.FROM_PUSH, true)
+                putExtra(FcmKeys.TYPE, type ?: FcmKeys.UNKNOWN_TYPE)
                 if (feedId != null) putExtra(FcmKeys.FEED_ID, feedId.toString())
                 if (notificationId != null) putExtra(FcmKeys.NOTIFICATION_ID, notificationId.toString())
             }

--- a/app/src/main/java/com/sseotdabwa/buyornot/notification/BuyOrNotMessagingService.kt
+++ b/app/src/main/java/com/sseotdabwa/buyornot/notification/BuyOrNotMessagingService.kt
@@ -76,11 +76,11 @@ class BuyOrNotMessagingService : FirebaseMessagingService() {
         createNotificationChannel()
 
         // 딥링크용 feedId/notificationId는 있을 때만 심는다(마케팅 알림은 없음).
-        // 반면 푸시 마커와 type은 유입 로깅(push_opened)에 필요하므로 마케팅 알림에도 항상 심는다.
+        // type은 유입 로깅(push_opened)의 탭 감지 마커라 마케팅 알림에도 항상 심어, 이 포그라운드
+        // 경로가 FCM이 만드는 백그라운드 launch Intent와 같은 extra 구성을 갖도록 맞춘다.
         val intent =
             Intent(this, MainActivity::class.java).apply {
                 flags = Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP
-                putExtra(FcmKeys.FROM_PUSH, true)
                 putExtra(FcmKeys.TYPE, type ?: FcmKeys.UNKNOWN_TYPE)
                 if (feedId != null) putExtra(FcmKeys.FEED_ID, feedId.toString())
                 if (notificationId != null) putExtra(FcmKeys.NOTIFICATION_ID, notificationId.toString())

--- a/app/src/main/java/com/sseotdabwa/buyornot/notification/FcmKeys.kt
+++ b/app/src/main/java/com/sseotdabwa/buyornot/notification/FcmKeys.kt
@@ -8,14 +8,15 @@ package com.sseotdabwa.buyornot.notification
 object FcmKeys {
     const val FEED_ID = "feedId"
     const val NOTIFICATION_ID = "notificationId"
-    const val TYPE = "type"
 
     /**
-     * 알림 탭으로 열린 Intent임을 표시하는 마커.
+     * 알림 유형. 5종 모두에 항상 포함되므로 **알림 탭으로 열린 Intent인지 판별하는 마커**로도 쓴다.
      *
-     * 마케팅 알림은 [FEED_ID]·[NOTIFICATION_ID]가 없어 이 마커가 없으면 탭 자체를 감지할 수 없다.
+     * 마케팅 알림은 [FEED_ID]·[NOTIFICATION_ID]가 없어 이 키로만 탭을 감지할 수 있다.
+     * 앱이 만든 마커를 쓰면 안 된다 — 백그라운드·종료 상태 탭은 FCM이 launch Intent를 만들기
+     * 때문에 서버 data 페이로드 키만 실려 오고 앱이 심은 extra는 존재하지 않는다.
      */
-    const val FROM_PUSH = "fromPush"
+    const val TYPE = "type"
 
     /** 서버가 [TYPE]을 주지 않았거나 알 수 없는 값일 때 로깅에 사용할 기본값. */
     const val UNKNOWN_TYPE = "UNKNOWN"

--- a/app/src/main/java/com/sseotdabwa/buyornot/notification/FcmKeys.kt
+++ b/app/src/main/java/com/sseotdabwa/buyornot/notification/FcmKeys.kt
@@ -9,4 +9,14 @@ object FcmKeys {
     const val FEED_ID = "feedId"
     const val NOTIFICATION_ID = "notificationId"
     const val TYPE = "type"
+
+    /**
+     * 알림 탭으로 열린 Intent임을 표시하는 마커.
+     *
+     * 마케팅 알림은 [FEED_ID]·[NOTIFICATION_ID]가 없어 이 마커가 없으면 탭 자체를 감지할 수 없다.
+     */
+    const val FROM_PUSH = "fromPush"
+
+    /** 서버가 [TYPE]을 주지 않았거나 알 수 없는 값일 때 로깅에 사용할 기본값. */
+    const val UNKNOWN_TYPE = "UNKNOWN"
 }

--- a/core/analytics/build.gradle.kts
+++ b/core/analytics/build.gradle.kts
@@ -40,4 +40,7 @@ dependencies {
 
     implementation(libs.hilt.android)
     ksp(libs.hilt.compiler)
+
+    // android.jar의 org.json은 유닛테스트에서 Stub!을 던지므로 실제 구현체를 테스트에만 넣는다.
+    testImplementation(libs.json)
 }

--- a/core/analytics/src/main/java/com/sseotdabwa/buyornot/core/analytics/AnalyticsEvent.kt
+++ b/core/analytics/src/main/java/com/sseotdabwa/buyornot/core/analytics/AnalyticsEvent.kt
@@ -31,4 +31,16 @@ sealed class AnalyticsEvent {
         val filledFields: List<String>,
         val lastStep: String?,
     ) : AnalyticsEvent()
+
+    /**
+     * 푸시 알림 탭. 유입 분석의 시작점이며 전환은 Mixpanel Funnel의 시간 순서로 잇는다.
+     *
+     * 마케팅 알림은 [feedId]·[notificationId]가 없으므로 null로 들어오고,
+     * 이때는 Mixpanel 속성 자체를 생략한다.
+     */
+    data class PushOpened(
+        val pushType: String,
+        val feedId: Long?,
+        val notificationId: Long?,
+    ) : AnalyticsEvent()
 }

--- a/core/analytics/src/main/java/com/sseotdabwa/buyornot/core/analytics/IdentityBufferingAnalytics.kt
+++ b/core/analytics/src/main/java/com/sseotdabwa/buyornot/core/analytics/IdentityBufferingAnalytics.kt
@@ -27,13 +27,15 @@ class IdentityBufferingAnalytics(
 
     override fun identify(userId: String?) {
         delegate.identify(userId)
-        val flushed =
-            synchronized(this) {
-                if (identified) return
-                identified = true
-                pending.toList().also { pending.clear() }
-            }
-        flushed.forEach(delegate::track)
+        // flush를 락 안에서 끝낸다. 락을 먼저 풀면 그 사이 다른 스레드의 track()이 identified=true를 보고
+        // 새 이벤트를 pending보다 먼저 흘려보낼 수 있다. delegate.track은 큐에 넣고 바로 반환하므로
+        // 최대 MAX_PENDING_EVENTS개를 락 안에서 처리해도 부담이 없다.
+        synchronized(this) {
+            if (identified) return
+            identified = true
+            pending.forEach(delegate::track)
+            pending.clear()
+        }
     }
 
     private companion object {

--- a/core/analytics/src/main/java/com/sseotdabwa/buyornot/core/analytics/IdentityBufferingAnalytics.kt
+++ b/core/analytics/src/main/java/com/sseotdabwa/buyornot/core/analytics/IdentityBufferingAnalytics.kt
@@ -1,0 +1,42 @@
+package com.sseotdabwa.buyornot.core.analytics
+
+/**
+ * 첫 [identify] 전에 발행된 이벤트를 큐에 담아 두었다가 identify 직후 순서대로 흘려보낸다.
+ *
+ * userId는 DataStore에서 비동기로 읽어오므로 콜드 스타트 직후에는 아직 등록돼 있지 않다.
+ * 그대로 흘려보내면 로그인 유저의 이벤트가 user_id=null(=비로그인)로 기록된다.
+ * 특히 push_opened는 MainActivity.onCreate에서 발행돼 identify보다 항상 앞선다.
+ */
+class IdentityBufferingAnalytics(
+    private val delegate: Analytics,
+) : Analytics {
+    private val pending = ArrayDeque<AnalyticsEvent>()
+    private var identified = false
+
+    override fun track(event: AnalyticsEvent) {
+        synchronized(this) {
+            if (!identified) {
+                // identify가 끝내 오지 않는 비정상 상황에서 큐가 무한히 자라지 않도록 오래된 것부터 버린다.
+                if (pending.size >= MAX_PENDING_EVENTS) pending.removeFirst()
+                pending.addLast(event)
+                return
+            }
+        }
+        delegate.track(event)
+    }
+
+    override fun identify(userId: String?) {
+        delegate.identify(userId)
+        val flushed =
+            synchronized(this) {
+                if (identified) return
+                identified = true
+                pending.toList().also { pending.clear() }
+            }
+        flushed.forEach(delegate::track)
+    }
+
+    private companion object {
+        const val MAX_PENDING_EVENTS = 100
+    }
+}

--- a/core/analytics/src/main/java/com/sseotdabwa/buyornot/core/analytics/MixpanelAnalytics.kt
+++ b/core/analytics/src/main/java/com/sseotdabwa/buyornot/core/analytics/MixpanelAnalytics.kt
@@ -19,7 +19,7 @@ class MixpanelAnalytics(
     }
 
     override fun track(event: AnalyticsEvent) {
-        val (name, props) = event.toMixpanel()
+        val (name, props) = event.toMixpanelEvent()
         mixpanel.track(name, props)
     }
 
@@ -31,43 +31,56 @@ class MixpanelAnalytics(
             JSONObject().apply { put("user_id", userId ?: JSONObject.NULL) },
         )
     }
+}
 
-    private fun AnalyticsEvent.toMixpanel(): Pair<String, JSONObject> {
-        val props = JSONObject()
-        val name =
-            when (this) {
-                is AnalyticsEvent.FeedViewed -> {
-                    props.put("first_visible_item_index", firstVisibleItemIndex)
-                    "feed_viewed"
-                }
-                is AnalyticsEvent.FeedExited -> {
-                    props.put("time_spent_seconds", timeSpentSeconds)
-                    props.put("last_visible_item_index", lastVisibleItemIndex)
-                    "feed_exited"
-                }
-                is AnalyticsEvent.VoteSubmitted -> {
-                    props.put("feed_id", feedId)
-                    props.put("vote_choice", voteChoice)
-                    props.put("feed_category", feedCategory)
-                    "vote_submitted"
-                }
-                is AnalyticsEvent.VoteCreateStarted -> {
-                    props.put("entry_source", entrySource)
-                    props.put("is_logged_in", isLoggedIn)
-                    "vote_create_started"
-                }
-                is AnalyticsEvent.VoteCreateCompleted -> {
-                    props.put("item_id", itemId)
-                    props.put("vote_title", voteTitle)
-                    props.put("option_count", optionCount)
-                    "vote_create_completed"
-                }
-                is AnalyticsEvent.VoteCreateAbandoned -> {
-                    props.put("filled_fields", JSONArray(filledFields))
-                    if (lastStep != null) props.put("last_step", lastStep)
-                    "vote_create_abandoned"
-                }
+/**
+ * 이벤트를 Mixpanel 이벤트명 + 속성으로 변환한다.
+ *
+ * [MixpanelAnalytics] 인스턴스 없이 검증할 수 있도록 top-level 함수로 둔다.
+ */
+internal fun AnalyticsEvent.toMixpanelEvent(): Pair<String, JSONObject> {
+    val props = JSONObject()
+    val name =
+        when (this) {
+            is AnalyticsEvent.FeedViewed -> {
+                props.put("first_visible_item_index", firstVisibleItemIndex)
+                "feed_viewed"
             }
-        return name to props
-    }
+            is AnalyticsEvent.FeedExited -> {
+                props.put("time_spent_seconds", timeSpentSeconds)
+                props.put("last_visible_item_index", lastVisibleItemIndex)
+                "feed_exited"
+            }
+            is AnalyticsEvent.VoteSubmitted -> {
+                props.put("feed_id", feedId)
+                props.put("vote_choice", voteChoice)
+                props.put("feed_category", feedCategory)
+                "vote_submitted"
+            }
+            is AnalyticsEvent.VoteCreateStarted -> {
+                props.put("entry_source", entrySource)
+                props.put("is_logged_in", isLoggedIn)
+                "vote_create_started"
+            }
+            is AnalyticsEvent.VoteCreateCompleted -> {
+                props.put("item_id", itemId)
+                props.put("vote_title", voteTitle)
+                props.put("option_count", optionCount)
+                "vote_create_completed"
+            }
+            is AnalyticsEvent.VoteCreateAbandoned -> {
+                props.put("filled_fields", JSONArray(filledFields))
+                if (lastStep != null) props.put("last_step", lastStep)
+                "vote_create_abandoned"
+            }
+            is AnalyticsEvent.PushOpened -> {
+                props.put("push_type", pushType)
+                // 마케팅 알림은 feedId·notificationId가 없다. null을 넣지 않고 속성 자체를 생략해
+                // Mixpanel에서 "속성 없음"으로 필터링할 수 있게 한다.
+                if (feedId != null) props.put("feed_id", feedId)
+                if (notificationId != null) props.put("notification_id", notificationId)
+                "push_opened"
+            }
+        }
+    return name to props
 }

--- a/core/analytics/src/main/java/com/sseotdabwa/buyornot/core/analytics/di/AnalyticsModule.kt
+++ b/core/analytics/src/main/java/com/sseotdabwa/buyornot/core/analytics/di/AnalyticsModule.kt
@@ -5,6 +5,7 @@ import com.mixpanel.android.mpmetrics.MixpanelAPI
 import com.sseotdabwa.buyornot.core.analytics.Analytics
 import com.sseotdabwa.buyornot.core.analytics.BuildConfig
 import com.sseotdabwa.buyornot.core.analytics.DebugAnalytics
+import com.sseotdabwa.buyornot.core.analytics.IdentityBufferingAnalytics
 import com.sseotdabwa.buyornot.core.analytics.MixpanelAnalytics
 import dagger.Module
 import dagger.Provides
@@ -26,21 +27,18 @@ object AnalyticsModule {
                 .getPackageInfo(context.packageName, 0)
                 .versionName
                 ?: "unknown"
-        return if (BuildConfig.DEBUG) {
-            DebugAnalytics(appVersion)
-        } else {
-            val mixpanel =
-                MixpanelAPI.getInstance(
-                    context,
-                    BuildConfig.MIXPANEL_TOKEN,
-                    true,
-                )
-            val appVersion =
-                context.packageManager
-                    .getPackageInfo(context.packageName, 0)
-                    .versionName
-                    ?: "unknown"
-            MixpanelAnalytics(mixpanel, appVersion)
-        }
+        val delegate =
+            if (BuildConfig.DEBUG) {
+                DebugAnalytics(appVersion)
+            } else {
+                val mixpanel =
+                    MixpanelAPI.getInstance(
+                        context,
+                        BuildConfig.MIXPANEL_TOKEN,
+                        true,
+                    )
+                MixpanelAnalytics(mixpanel, appVersion)
+            }
+        return IdentityBufferingAnalytics(delegate)
     }
 }

--- a/core/analytics/src/test/java/com/sseotdabwa/buyornot/core/analytics/IdentityBufferingAnalyticsTest.kt
+++ b/core/analytics/src/test/java/com/sseotdabwa/buyornot/core/analytics/IdentityBufferingAnalyticsTest.kt
@@ -1,0 +1,105 @@
+package com.sseotdabwa.buyornot.core.analytics
+
+import org.junit.Before
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class IdentityBufferingAnalyticsTest {
+    private lateinit var fake: FakeAnalytics
+    private lateinit var sut: IdentityBufferingAnalytics
+
+    @Before
+    fun setUp() {
+        fake = FakeAnalytics()
+        sut = IdentityBufferingAnalytics(fake)
+    }
+
+    @Test
+    fun `identify_전에_발행된_이벤트는_delegate로_전달되지_않는다`() {
+        sut.track(AnalyticsEvent.PushOpened(pushType = "TYPE_A", feedId = 1L, notificationId = 10L))
+        sut.track(AnalyticsEvent.FeedViewed(firstVisibleItemIndex = 0))
+
+        assertTrue(fake.trackCalls.isEmpty())
+    }
+
+    @Test
+    fun `identify_직후_보류됐던_이벤트가_원래_순서대로_전달된다`() {
+        val event1 = AnalyticsEvent.PushOpened(pushType = "TYPE_A", feedId = 1L, notificationId = 10L)
+        val event2 = AnalyticsEvent.FeedViewed(firstVisibleItemIndex = 0)
+        val event3 = AnalyticsEvent.FeedViewed(firstVisibleItemIndex = 5)
+        sut.track(event1)
+        sut.track(event2)
+        sut.track(event3)
+
+        sut.identify("user-42")
+
+        val trackedEvents = fake.trackCalls
+        assertEquals(3, trackedEvents.size)
+        assertEquals(event1, trackedEvents[0])
+        assertEquals(event2, trackedEvents[1])
+        assertEquals(event3, trackedEvents[2])
+    }
+
+    @Test
+    fun `identify가_delegate로_전달된_뒤에_보류_이벤트가_flush된다`() {
+        sut.track(AnalyticsEvent.PushOpened(pushType = "TYPE_A", feedId = 1L, notificationId = 10L))
+
+        sut.identify("user-42")
+
+        val calls = fake.allCalls
+        val identifyIndex = calls.indexOfFirst { it is FakeAnalytics.Call.Identify }
+        val firstTrackIndex = calls.indexOfFirst { it is FakeAnalytics.Call.Track }
+        assertTrue(identifyIndex >= 0)
+        assertTrue(firstTrackIndex > identifyIndex)
+    }
+
+    @Test
+    fun `identify_이후_발행된_이벤트는_버퍼링_없이_바로_전달된다`() {
+        sut.identify("user-42")
+
+        val event = AnalyticsEvent.FeedViewed(firstVisibleItemIndex = 3)
+        sut.track(event)
+
+        assertEquals(listOf(event), fake.trackCalls)
+    }
+
+    @Test
+    fun `identify가_두_번_호출돼도_이미_flush된_이벤트가_다시_전달되지_않는다`() {
+        sut.track(AnalyticsEvent.PushOpened(pushType = "TYPE_A", feedId = 1L, notificationId = 10L))
+
+        sut.identify("user-42")
+        sut.identify("user-42")
+
+        assertEquals(1, fake.trackCalls.size)
+    }
+
+    // -----------------------------------------------------------------------
+    // Fake
+    // -----------------------------------------------------------------------
+
+    private class FakeAnalytics : Analytics {
+        sealed class Call {
+            data class Track(
+                val event: AnalyticsEvent,
+            ) : Call()
+
+            data class Identify(
+                val userId: String?,
+            ) : Call()
+        }
+
+        val allCalls = mutableListOf<Call>()
+
+        val trackCalls: List<AnalyticsEvent>
+            get() = allCalls.filterIsInstance<Call.Track>().map { it.event }
+
+        override fun track(event: AnalyticsEvent) {
+            allCalls.add(Call.Track(event))
+        }
+
+        override fun identify(userId: String?) {
+            allCalls.add(Call.Identify(userId))
+        }
+    }
+}

--- a/core/analytics/src/test/java/com/sseotdabwa/buyornot/core/analytics/MixpanelEventMapperTest.kt
+++ b/core/analytics/src/test/java/com/sseotdabwa/buyornot/core/analytics/MixpanelEventMapperTest.kt
@@ -1,0 +1,65 @@
+package com.sseotdabwa.buyornot.core.analytics
+
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class MixpanelEventMapperTest {
+    @Test
+    fun `푸시_알림_탭은_push_opened로_매핑된다`() {
+        val (name, _) =
+            AnalyticsEvent
+                .PushOpened(
+                    pushType = "MY_FEED_VOTED_10",
+                    feedId = 123L,
+                    notificationId = 42L,
+                ).toMixpanelEvent()
+
+        assertEquals("push_opened", name)
+    }
+
+    @Test
+    fun `푸시_알림_탭의_속성이_모두_매핑된다`() {
+        val (_, props) =
+            AnalyticsEvent
+                .PushOpened(
+                    pushType = "MY_FEED_VOTED_10",
+                    feedId = 123L,
+                    notificationId = 42L,
+                ).toMixpanelEvent()
+
+        assertEquals("MY_FEED_VOTED_10", props.getString("push_type"))
+        assertEquals(123L, props.getLong("feed_id"))
+        assertEquals(42L, props.getLong("notification_id"))
+    }
+
+    @Test
+    fun `마케팅_알림은_feed_id와_notification_id_속성이_생략된다`() {
+        val (_, props) =
+            AnalyticsEvent
+                .PushOpened(
+                    pushType = "MARKETING_NO_VOTE",
+                    feedId = null,
+                    notificationId = null,
+                ).toMixpanelEvent()
+
+        assertEquals("MARKETING_NO_VOTE", props.getString("push_type"))
+        assertFalse(props.has("feed_id"))
+        assertFalse(props.has("notification_id"))
+    }
+
+    @Test
+    fun `feedId만_있으면_notification_id_속성만_생략된다`() {
+        val (_, props) =
+            AnalyticsEvent
+                .PushOpened(
+                    pushType = "MY_FEED_CLOSED",
+                    feedId = 123L,
+                    notificationId = null,
+                ).toMixpanelEvent()
+
+        assertTrue(props.has("feed_id"))
+        assertFalse(props.has("notification_id"))
+    }
+}

--- a/domain/src/main/java/com/sseotdabwa/buyornot/domain/model/Notification.kt
+++ b/domain/src/main/java/com/sseotdabwa/buyornot/domain/model/Notification.kt
@@ -15,8 +15,11 @@ data class Notification(
 )
 
 enum class NotificationType {
+    MY_FEED_VOTED_1,
+    MY_FEED_VOTED_10,
     MY_FEED_CLOSED,
     PARTICIPATED_FEED_CLOSED,
+    MARKETING_NO_VOTE,
     UNKNOWN,
     ;
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -47,6 +47,9 @@ chucker = "4.3.1"
 # Analytics
 mixpanel = "7.5.3"
 
+# org.json 실제 구현체. android.jar의 org.json은 유닛테스트에서 Stub!을 던지므로 테스트에서만 사용한다.
+json = "20250517"
+
 # Firebase
 firebaseBom = "34.9.0"
 googleServices = "4.5.0"
@@ -138,6 +141,7 @@ lottie-compose = { group = "com.airbnb.android", name = "lottie-compose", versio
 
 # Analytics
 mixpanel-android = { group = "com.mixpanel.android", name = "mixpanel-android", version.ref = "mixpanel" }
+json = { group = "org.json", name = "json", version.ref = "json" }
 
 # Chucker
 chucker = { group = "com.github.chuckerteam.chucker", name = "library", version.ref = "chucker" }


### PR DESCRIPTION
## 🛠 Related issue
[//]: # (해당하는 이슈 번호 달아주기)
closed #132

어떤 변경사항이 있었나요?
- [x] 🐞 BugFix Something isn't working
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [x] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (Junit, etc.)

## ✅ CheckPoint
[//]: # (PR 요구사항 확인)
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 컨벤션에 맞게 작성했습니다. (필수)
- [x] merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕) (필수)
- [ ] Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다. (필수)
- [x] BugFix의 경우, 버그의 원인을 파악하였습니다. (선택)

## ✏️ Work Description
[//]: # (작업 내용 간단 소개)
- **`push_opened` 이벤트 추가** — 어떤 종류의 푸시가 유입을 만들고 그 유저가 실제 행동까지 이어지는지 Mixpanel에서 분석할 수 있게 합니다. 속성은 `push_type` / `feed_id` / `notification_id`이고, 마케팅 알림은 `feedId`·`notificationId`가 없으므로 `null` 대신 **속성 자체를 생략**합니다.
- **유입 로깅을 딥링크 처리와 분리** — 기존 `handleFeedDeepLink`는 `feedId`가 없으면 조기 반환하므로, 같은 경로에 두면 마케팅 알림 탭이 통째로 누락됩니다.
- **탭 판별을 서버 data 키인 `type`의 존재로** — 처음엔 앱이 심은 마커로 판별했는데 백그라운드·종료 상태 탭이 전부 누락되는 문제가 있어 수정했습니다 (아래 To Reviewers 참고).
- **중복 발행 방지** — `onCreate`/`onNewIntent` 이중 경로와 화면 회전·프로세스 재생성에 대비해 처리 직후 intent extras를 소비합니다.
- **`NotificationType`에 백엔드 신규 타입 3종 추가** (`MY_FEED_VOTED_1`, `MY_FEED_VOTED_10`, `MARKETING_NO_VOTE`) — 기존 enum에 값이 3개뿐이라 신규 알림이 전부 `UNKNOWN`으로 떨어져 알림 목록이 깨지던 **실사용 버그**를 함께 해소했습니다.
- **매핑 로직을 `toMixpanelEvent()` top-level 함수로 분리** — `MixpanelAPI` 인스턴스 없이 검증할 수 있게 하고 단위 테스트 4건을 추가했습니다.

## 😅 Uncompleted Tasks
[//]: # (없다면 N/A)
- [ ] **`type` 누락 시 백그라운드 탭에서 `push_opened` 미발행** — 아래 To Reviewers 5번. 백엔드가 5종 모두에 `type`을 넣는다는 계약이 지켜지면 실제 영향은 없어 이번 PR에서는 방어하지 않았습니다. 방어할지 계약에 맡길지 논의 필요
- [ ] 마케팅 캠페인 단위(A/B) 분석 — payload에 `campaignId`류 키가 없어 백엔드 합의 후 v2.1로 분리
- [ ] `screen` payload 키 — 현재 `NOTIFICATIONS` 고정 + 협의 예정이라 이번엔 로깅에 사용하지 않음

## 📢 To Reviewers
[//]: # (reviewer가 알면 좋은 내용들)

**1. `push_received`를 의도적으로 넣지 않았습니다.** 백엔드 payload가 `notification`과 `data`를 동시에 담고 있어, FCM 스펙상 앱이 백그라운드·종료 상태면 `onMessageReceived`가 호출되지 않고 시스템 트레이가 알림을 직접 그립니다. 앱에서 수신을 집계하면 포그라운드 사용자만 잡혀 **CTR 분모가 정반대로 왜곡**됩니다. 발송량·도달률은 서버 / Firebase Console 집계에 위임합니다.

**2. 두 번째 커밋(`92937b2`)이 이 PR의 핵심 함정입니다.** 처음엔 앱이 심은 `FROM_PUSH` 마커로 탭을 판별했는데, 위 1번과 같은 이유로 백그라운드·종료 상태에서는 커스텀 `PendingIntent`가 애초에 만들어지지 않습니다. FCM이 만든 launch Intent에는 서버 data 키만 실려 오므로 앱 마커는 존재하지 않고, 결과적으로 **유입 분석에서 가장 중요한 케이스가 전부 누락**됩니다. 서버가 5종 모두에 보내는 `type`의 존재로 판별하도록 바꿔 포그라운드/백그라운드 두 경로를 함께 커버합니다.

> 이 수정이 실제로 유효한지 기기에서 확인했습니다. 검증 도중 기기에 깔려 있던 APK가 우연히 `92937b2` 이전 빌드였는데, 그 상태로 알림을 탭하니 `handleFeedDeepLink`만 찍히고 `push_opened`는 누락됐습니다. 수정본을 설치한 뒤 동일 조건에서 정상 발행됐습니다. **버그 재현 → 수정 확인이 같은 기기에서 이어졌습니다.**

**3. 어트리뷰션에 앱 상태를 두지 않았습니다.** `last_push_type` 같은 super property는 푸시를 타지 않은 세션까지 오염시키고, `entry_source` 파이핑은 여러 ViewModel을 건드려야 합니다. 대신 Mixpanel Funnel의 시간 순서로만 잇습니다 (`push_opened` → `feed_viewed` → `vote_submitted`). 덕분에 수정 범위가 `MainActivity` + `AnalyticsEvent` 수준으로 작습니다.

**4. 논의가 필요할 수 있는 두 가지** — 마음에 안 드시면 되돌릴 수 있습니다.
- `core/analytics`에 `org.json:json`을 **`testImplementation`으로만** 추가했습니다. `android.jar`의 `org.json`은 유닛테스트에서 `Stub!`을 던져서, Robolectric 없이 실제 매핑 코드를 테스트하려면 필요했습니다. 프로덕션 APK에는 영향이 없습니다.
- 그에 맞춰 `MixpanelAnalytics`의 `private fun AnalyticsEvent.toMixpanel()`을 top-level `internal fun toMixpanelEvent()`로 옮겼습니다. 기존 6개 이벤트의 매핑 내용은 그대로이고 위치와 들여쓰기만 바뀌어서 diff가 실제보다 크게 보입니다.

**5. [검증 중 발견] `type`이 없으면 포그라운드/백그라운드 동작이 갈립니다.** 정상 payload에서는 두 경로가 완전히 동일하게 동작하는 걸 확인했지만, 서버가 `type`을 빠뜨리면 아래처럼 갈립니다. 같은 payload(`type` 없이 `feedId`만)를 두 상태에서 각각 보내 탭한 결과입니다.

```
# 포그라운드 탭
handlePushOpened - pushType=UNKNOWN, feedId=123, notificationId=42
Analytics: PushOpened(pushType=UNKNOWN, ...)     ← 발행됨

# 백그라운드 탭 (동일 payload)
handleFeedDeepLink - resolved feedId=123, notificationId=42
                                                  ← push_opened 없음 (발생 건수 0)
```

포그라운드는 `showFeedNotification`이 `type ?: UNKNOWN`으로 보정해 심지만, 백그라운드는 FCM이 서버 `data`를 그대로 옮기므로 `type` extra 자체가 없고 → `hasExtra(TYPE)`가 false → **`push_opened`가 통째로 누락**됩니다. 딥링크는 `feedId`로 판별하니 정상 동작해서, 유저 눈에는 멀쩡해 보이고 로깅만 조용히 빠집니다 — 2번 함정과 같은 종류의 실패 모드입니다.

백엔드 계약(5종 모두 `type` 포함)이 지켜지면 실제 영향은 없어 이번 PR에서는 건드리지 않았습니다. 참고로 Notion 스펙의 «(서버가 type 미전송) → `push_type` = `UNKNOWN`» 행은 **포그라운드에서만 성립**합니다.

**6. [검증 중 발견 → 이 PR에서 수정함] 콜드 스타트 탭에서 `user_id`가 `null`로 기록되던 문제.** 같은 로그인 계정인데 앱 상태에 따라 갈렸습니다.

```
# 백그라운드 탭
PushOpened(...) [platform=android, app_version=0.3.3, user_id=33]
# 종료 상태 탭  ← 수정 전
PushOpened(...) [platform=android, app_version=0.3.3, user_id=null]
```

`identify()`가 `BuyOrNotViewModel`에서 DataStore Flow로 비동기 호출되는데 이건 `setContent` 이후라 `onCreate`의 `handlePushOpened()`보다 **항상 늦습니다**. 스펙상 `user_id = null`은 «비로그인»을 뜻하므로 로그인 유저의 푸시 유입이 게스트로 오분류되고, 종료 상태 탭이 푸시 유입의 큰 비중일 테니 `user_id` breakdown이 왜곡됩니다.

`push_opened`만의 문제가 아니라 **콜드 스타트 직후 발행되는 모든 이벤트**(`feed_viewed` 등)가 같은 영향을 받아서, 개별 호출부가 아니라 Analytics 레이어에서 처리했습니다. 첫 `identify()` 전까지 `track()` 이벤트를 큐에 담았다가 identify 직후 순서대로 flush하는 `IdentityBufferingAnalytics` 데코레이터를 추가하고 Hilt가 이걸로 감싸 제공합니다. `DebugAnalytics`/`MixpanelAnalytics`는 건드리지 않았습니다.

`delegate.identify()`를 먼저 호출한 **뒤에** flush해야 보류 이벤트에 올바른 user_id가 붙습니다 — 순서가 이 수정의 핵심이라 단위 테스트로 고정해 뒀습니다. identify가 끝내 오지 않는 비정상 상황에 대비해 큐 상한(100)을 두고 오래된 것부터 버립니다.

수정 후 실기기 콜드 스타트 재검증 (로그 타임스탬프가 동작을 그대로 보여줍니다):

```
23:45:07.319  handlePushOpened - pushType=MY_FEED_VOTED_10, feedId=123, notificationId=42
23:45:07.666  identify: userId=33                          ← 347ms 뒤 DataStore 해석 완료
23:45:07.666  PushOpened(...) [..., user_id=33]            ← identify 직후 flush
```

## 🔍 검증 결과

**단위/빌드:** `:core:analytics:testDebugUnitTest` 9건 통과(0 failures / 0 skipped — 기존 4건 + `IdentityBufferingAnalytics` 5건), `:app:compileDebugKotlin` 통과, `ktlintCheck` 통과.

**기기 검증 (2026-07-30, Galaxy Z Flip `SM_F766N` / `com.sseotdabwa.buyornot.dev`):** FCM HTTP v1으로 실제 푸시를 발송해 QA 4항목 전부 통과.

| QA 항목 | 결과 |
|---|---|
| ① 앱 **종료** 상태 탭 | ✅ `PushOpened(pushType=MY_FEED_VOTED_10, feedId=123, notificationId=42)` 1회 |
| ② 앱 **백그라운드** 탭 | ✅ 1회, 속성 정확 |
| ③ **마케팅** 푸시 탭 | ✅ `PushOpened(pushType=MARKETING_NO_VOTE, feedId=null, notificationId=null)` 1회, 딥링크 경로 미진입 |
| ④ 탭 후 **화면 회전** | ✅ 0회 (중복 없음) |
| (추가) **포그라운드** 탭 | ✅ 1회, 속성 정확 — 위 ①②와 동일 결과 |
| (추가) 콜드 스타트 `user_id` | ✅ 6번 수정 후 `user_id=33`으로 정상 기록 |

종료 상태 테스트는 `adb shell am force-stop`이 아니라 `am kill`로 했습니다. 삼성 기기에서 강제 중지된 앱은 사용자가 직접 실행할 때까지 FCM을 아예 받지 못해, 알림이 안 뜨는 걸 버그로 오진하게 됩니다.

CLI로 푸시를 쏴서 검증하는 전체 절차(서비스 계정 키·Project ID·기기 FCM 토큰 준비부터 함정까지)는 [Notion 로깅 스펙 문서](https://app.notion.com/p/3ac4d6f383cf8058af8ff86ebfb0d54a) 하단 «부록 — CLI로 푸시 알림 보내서 테스트하는 법»에 정리해 뒀습니다.

## 📃 RCA 룰
- R: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
- C: 웬만하면 반영해 주세요. (Comment)
- A: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - 푸시/딥링크 진입 시 알림 유형과 콘텐츠 식별자를 함께 분석 이벤트로 전송합니다.
  - 마케팅 푸시에도 유형을 기록하고, 피드 투표 및 마케팅 알림을 신규 알림 유형으로 지원합니다.
  - 숫자형/문자열형 식별자를 모두 인식해 딥링크 이동을 더 안정적으로 합니다.
- **버그 수정**
  - 재처리 시 중복 분석 이벤트가 발생하지 않도록 개선했으며, 푸시/딥링크 처리 순서도 안정화했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
