### PR TITLE
⚙️ Setting - Firebase Performance Monitoring 연동 (dev/prod 성능 모니터링)

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -8,6 +8,58 @@ on:
   pull_request:
 
 jobs:
+  unit-test:
+    runs-on: ubuntu-latest
+    if: github.actor != 'github-actions[bot]'
+    concurrency:
+      group: unit-test-${{ github.ref }}
+      cancel-in-progress: true
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref || github.ref }}
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Create local.properties
+        run: |
+          echo "signed.store.file=keystore.jks" >> local.properties
+          echo "signed.store.password=${{ secrets.SIGNED_STORE_PASSWORD }}" >> local.properties
+          echo "signed.key.alias=${{ secrets.SIGNED_KEY_ALIAS }}" >> local.properties
+          echo "signed.key.password=${{ secrets.SIGNED_KEY_PASSWORD }}" >> local.properties
+          echo "debug.base.url=${{ secrets.DEBUG_BASE_URL }}" >> local.properties
+          echo "release.base.url=${{ secrets.RELEASE_BASE_URL }}" >> local.properties
+          echo "google.webClientId=${{ secrets.GOOGLE_WEB_CLIENT_ID }}" >> local.properties
+          echo "kakao.nativeAppKey=${{ secrets.KAKAO_NATIVE_APP_KEY }}" >> local.properties
+          echo "kakao.nativeAppKeyDebug=${{ secrets.KAKAO_NATIVE_APP_KEY_DEBUG }}" >> local.properties
+          echo "mixpanel.token=${{ secrets.MIXPANEL_TOKEN }}" >> local.properties
+
+      - name: Decode Keystore
+        run: echo "${{ secrets.KEYSTORE_BASE64 }}" | base64 --decode > app/keystore.jks
+
+      - name: Decode google-services.json
+        run: echo "${{ secrets.GOOGLE_SERVICES_JSON_BASE64 }}" | base64 --decode > app/google-services.json
+
+      - name: Configure Gradle
+        uses: gradle/actions/setup-gradle@v3
+
+      - name: Run unit tests
+        run: ./gradlew testDebugUnitTest
+
+      - name: Upload test reports
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: unit-test-reports
+          path: '**/build/reports/tests/testDebugUnitTest/'
+          retention-days: 7
+
   ktlint:
     runs-on: ubuntu-latest
     if: github.actor != 'github-actions[bot]'

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -10,6 +10,9 @@ on:
 jobs:
   unit-test:
     runs-on: ubuntu-latest
+    # 이 잡은 git 쓰기가 필요 없으므로 토큰을 읽기 전용으로 축소한다.
+    permissions:
+      contents: read
     if: github.actor != 'github-actions[bot]'
     concurrency:
       group: unit-test-${{ github.ref }}
@@ -20,6 +23,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref || github.ref }}
+          # Gradle 빌드 스크립트에 토큰이 노출되지 않도록 로컬 git 설정에 남기지 않는다.
+          persist-credentials: false
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -21,8 +21,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        # ref를 지정하지 않아 PR에서는 base와 병합된 merge ref를 검증한다.
+        # (브랜치 이름으로 체크아웃하면 트리거 커밋이 아닌 최신 tip을 테스트할 수 있다)
         with:
-          ref: ${{ github.head_ref || github.ref }}
           # Gradle 빌드 스크립트에 토큰이 노출되지 않도록 로컬 git 설정에 남기지 않는다.
           persist-credentials: false
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -10,6 +10,7 @@ plugins {
     alias(libs.plugins.google.services)
     alias(libs.plugins.firebase.crashlytics)
     alias(libs.plugins.firebase.appdistribution)
+    alias(libs.plugins.firebase.perf)
 }
 
 val localProperties =
@@ -132,6 +133,7 @@ dependencies {
     implementation(platform(libs.firebase.bom))
     implementation(libs.firebase.messaging)
     implementation(libs.firebase.crashlytics)
+    implementation(libs.firebase.performance)
 
     ksp(libs.hilt.compiler)
 

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application>
+        <!-- dev 빌드에서 Performance Monitoring 수집 결과를 logcat으로 확인 (adb logcat -s FirebasePerformance) -->
+        <meta-data
+            android:name="firebase_performance_logcat_enabled"
+            android:value="true" />
+    </application>
+
+</manifest>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,6 +11,7 @@ plugins {
     alias(libs.plugins.google.services) apply false
     alias(libs.plugins.firebase.crashlytics) apply false
     alias(libs.plugins.firebase.appdistribution) apply false
+    alias(libs.plugins.firebase.perf) apply false
 }
 
 apply(from = "gradle/dependencyGraph.gradle")

--- a/core/analytics/build.gradle.kts
+++ b/core/analytics/build.gradle.kts
@@ -38,6 +38,9 @@ android {
 dependencies {
     implementation(libs.mixpanel.android)
 
+    implementation(platform(libs.firebase.bom))
+    implementation(libs.firebase.performance)
+
     implementation(libs.hilt.android)
     ksp(libs.hilt.compiler)
 }

--- a/core/analytics/src/main/java/com/sseotdabwa/buyornot/core/analytics/performance/FirebasePerformanceTracer.kt
+++ b/core/analytics/src/main/java/com/sseotdabwa/buyornot/core/analytics/performance/FirebasePerformanceTracer.kt
@@ -1,0 +1,35 @@
+package com.sseotdabwa.buyornot.core.analytics.performance
+
+import com.google.firebase.perf.FirebasePerformance
+import com.google.firebase.perf.metrics.Trace
+
+/**
+ * Firebase Performance Monitoring 기반 구현.
+ *
+ * debug(dev) / release(prod) 모두 이 구현을 쓴다. 두 빌드의 applicationId가 같은
+ * Firebase 프로젝트에 별도 앱으로 등록돼 있어 콘솔에서 환경이 구분된다.
+ * dev 빌드는 `firebase_performance_logcat_enabled` 로 로컬 확인도 가능하다.
+ */
+internal class FirebasePerformanceTracer(
+    private val firebasePerformance: FirebasePerformance,
+) : Performance {
+    override fun newTrace(name: String): PerfTrace = SingleShotPerfTrace(FirebasePerfTrace(firebasePerformance.newTrace(name)))
+}
+
+private class FirebasePerfTrace(
+    private val trace: Trace,
+) : PerfTrace {
+    override fun start() = trace.start()
+
+    override fun stop() = trace.stop()
+
+    override fun putAttribute(
+        name: String,
+        value: String,
+    ) = trace.putAttribute(name, value)
+
+    override fun putMetric(
+        name: String,
+        value: Long,
+    ) = trace.putMetric(name, value)
+}

--- a/core/analytics/src/main/java/com/sseotdabwa/buyornot/core/analytics/performance/PerfTrace.kt
+++ b/core/analytics/src/main/java/com/sseotdabwa/buyornot/core/analytics/performance/PerfTrace.kt
@@ -1,0 +1,40 @@
+package com.sseotdabwa.buyornot.core.analytics.performance
+
+/**
+ * 시작과 종료가 서로 다른 지점에서 일어나는 구간을 계측하는 Trace.
+ *
+ * 속성/측정항목은 Firebase 제한을 따른다 — 커스텀 속성 5개, 측정항목 32개,
+ * 속성 이름은 32자 이내의 `A-Z a-z _` 조합.
+ */
+interface PerfTrace {
+    fun start()
+
+    fun stop()
+
+    fun putAttribute(
+        name: String,
+        value: String,
+    )
+
+    fun putMetric(
+        name: String,
+        value: Long,
+    )
+}
+
+/** 계측을 하지 않는 Trace. 테스트나 수집 비활성 환경에서 사용한다. */
+object NoOpPerfTrace : PerfTrace {
+    override fun start() = Unit
+
+    override fun stop() = Unit
+
+    override fun putAttribute(
+        name: String,
+        value: String,
+    ) = Unit
+
+    override fun putMetric(
+        name: String,
+        value: Long,
+    ) = Unit
+}

--- a/core/analytics/src/main/java/com/sseotdabwa/buyornot/core/analytics/performance/Performance.kt
+++ b/core/analytics/src/main/java/com/sseotdabwa/buyornot/core/analytics/performance/Performance.kt
@@ -1,0 +1,32 @@
+package com.sseotdabwa.buyornot.core.analytics.performance
+
+/**
+ * 커스텀 구간 성능 계측 진입점.
+ *
+ * feature 모듈이 Firebase에 직접 의존하지 않도록 하는 추상화 계층이다.
+ * 구현은 [FirebasePerformanceTracer] 하나이며, DI 시점에 주입된다.
+ */
+interface Performance {
+    /** 아직 시작되지 않은 Trace를 만든다. 이름은 [TraceNames] 상수를 쓴다. */
+    fun newTrace(name: String): PerfTrace
+}
+
+/**
+ * 커스텀 Trace 이름 모음.
+ *
+ * Firebase 콘솔에서 이름으로 지표를 찾게 되므로 한 곳에 모아 관리한다.
+ * 이름은 100자 이내이며 선행 공백/밑줄을 쓸 수 없다.
+ */
+object TraceNames {
+    /**
+     * 스플래시 진입부터 홈/로그인 분기가 결정되기까지.
+     * 고정 딜레이는 포함되고 업데이트 팝업 대기(사용자 반응 시간)는 제외된다.
+     */
+    const val SPLASH_TO_NAVIGATION = "splash_to_navigation"
+
+    /** 홈 피드 최초 로딩 — 로딩 시작부터 목록이 상태에 반영되기까지. */
+    const val FEED_FIRST_LOAD = "feed_first_load"
+
+    /** 투표 요청 왕복. UI는 낙관적 업데이트라 체감 시간과 분리해 본다. */
+    const val VOTE_REQUEST = "vote_request"
+}

--- a/core/analytics/src/main/java/com/sseotdabwa/buyornot/core/analytics/performance/SingleShotPerfTrace.kt
+++ b/core/analytics/src/main/java/com/sseotdabwa/buyornot/core/analytics/performance/SingleShotPerfTrace.kt
@@ -1,0 +1,45 @@
+package com.sseotdabwa.buyornot.core.analytics.performance
+
+/**
+ * Trace 하나가 한 번만 측정되도록 보장하는 데코레이터.
+ *
+ * 홈 피드 로딩처럼 트리거가 여러 경로에서 겹쳐 들어오는 구간은 [start] 가 중복
+ * 호출되거나 [stop] 이 [start] 없이 호출될 수 있다. Firebase Trace는 그 경우
+ * 경고를 남기고 구간을 버리므로, 지표가 조용히 비는 대신 첫 측정만 남긴다.
+ *
+ * 종료 후의 속성/측정항목 추가도 무시한다 — Firebase에서 반영되지 않는 호출이다.
+ */
+class SingleShotPerfTrace(
+    private val delegate: PerfTrace,
+) : PerfTrace {
+    private var started = false
+    private var stopped = false
+
+    override fun start() {
+        if (started) return
+        started = true
+        delegate.start()
+    }
+
+    override fun stop() {
+        if (!started || stopped) return
+        stopped = true
+        delegate.stop()
+    }
+
+    override fun putAttribute(
+        name: String,
+        value: String,
+    ) {
+        if (stopped) return
+        delegate.putAttribute(name, value)
+    }
+
+    override fun putMetric(
+        name: String,
+        value: Long,
+    ) {
+        if (stopped) return
+        delegate.putMetric(name, value)
+    }
+}

--- a/core/analytics/src/main/java/com/sseotdabwa/buyornot/core/analytics/performance/di/PerformanceModule.kt
+++ b/core/analytics/src/main/java/com/sseotdabwa/buyornot/core/analytics/performance/di/PerformanceModule.kt
@@ -1,0 +1,18 @@
+package com.sseotdabwa.buyornot.core.analytics.performance.di
+
+import com.google.firebase.perf.FirebasePerformance
+import com.sseotdabwa.buyornot.core.analytics.performance.FirebasePerformanceTracer
+import com.sseotdabwa.buyornot.core.analytics.performance.Performance
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object PerformanceModule {
+    @Provides
+    @Singleton
+    fun providePerformance(): Performance = FirebasePerformanceTracer(FirebasePerformance.getInstance())
+}

--- a/core/analytics/src/test/java/com/sseotdabwa/buyornot/core/analytics/performance/SingleShotPerfTraceTest.kt
+++ b/core/analytics/src/test/java/com/sseotdabwa/buyornot/core/analytics/performance/SingleShotPerfTraceTest.kt
@@ -1,0 +1,106 @@
+package com.sseotdabwa.buyornot.core.analytics.performance
+
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class SingleShotPerfTraceTest {
+    private class RecordingPerfTrace : PerfTrace {
+        val calls = mutableListOf<String>()
+
+        override fun start() {
+            calls += "start"
+        }
+
+        override fun stop() {
+            calls += "stop"
+        }
+
+        override fun putAttribute(
+            name: String,
+            value: String,
+        ) {
+            calls += "attribute:$name=$value"
+        }
+
+        override fun putMetric(
+            name: String,
+            value: Long,
+        ) {
+            calls += "metric:$name=$value"
+        }
+    }
+
+    @Test
+    fun `start와_stop은_delegate로_한_번씩_전달된다`() {
+        val delegate = RecordingPerfTrace()
+        val trace = SingleShotPerfTrace(delegate)
+
+        trace.start()
+        trace.stop()
+
+        assertEquals(listOf("start", "stop"), delegate.calls)
+    }
+
+    @Test
+    fun `중복_start는_무시된다`() {
+        val delegate = RecordingPerfTrace()
+        val trace = SingleShotPerfTrace(delegate)
+
+        trace.start()
+        trace.start()
+        trace.start()
+
+        assertEquals(listOf("start"), delegate.calls)
+    }
+
+    @Test
+    fun `start_없이_호출된_stop은_무시된다`() {
+        val delegate = RecordingPerfTrace()
+        val trace = SingleShotPerfTrace(delegate)
+
+        trace.stop()
+
+        assertEquals(emptyList<String>(), delegate.calls)
+    }
+
+    @Test
+    fun `중복_stop은_무시된다`() {
+        val delegate = RecordingPerfTrace()
+        val trace = SingleShotPerfTrace(delegate)
+
+        trace.start()
+        trace.stop()
+        trace.stop()
+
+        assertEquals(listOf("start", "stop"), delegate.calls)
+    }
+
+    @Test
+    fun `종료_전_속성과_측정항목은_전달된다`() {
+        val delegate = RecordingPerfTrace()
+        val trace = SingleShotPerfTrace(delegate)
+
+        trace.start()
+        trace.putAttribute("result", "success")
+        trace.putMetric("feed_count", 20L)
+        trace.stop()
+
+        assertEquals(
+            listOf("start", "attribute:result=success", "metric:feed_count=20", "stop"),
+            delegate.calls,
+        )
+    }
+
+    @Test
+    fun `종료_후_속성과_측정항목_추가는_무시된다`() {
+        val delegate = RecordingPerfTrace()
+        val trace = SingleShotPerfTrace(delegate)
+
+        trace.start()
+        trace.stop()
+        trace.putAttribute("result", "success")
+        trace.putMetric("feed_count", 20L)
+
+        assertEquals(listOf("start", "stop"), delegate.calls)
+    }
+}

--- a/core/common/src/test/java/com/sseotdabwa/buyornot/core/common/util/TimeUtilsTest.kt
+++ b/core/common/src/test/java/com/sseotdabwa/buyornot/core/common/util/TimeUtilsTest.kt
@@ -49,10 +49,18 @@ class TimeUtilsTest {
     }
 
     @Test
-    fun `7일을 초과할 경우 절대 날짜로 표시된다`() {
+    fun `7일_초과_14일_미만일_경우에도_1주_전으로_표시된다`() {
         val past = now.minusDays(8)
         val isoString = past.format(DateTimeFormatter.ISO_DATE_TIME)
         val result = TimeUtils.formatRelativeTime(isoString, now)
-        assertEquals("2026.2.14", result)
+        assertEquals("1주 전", result)
+    }
+
+    @Test
+    fun `14일_이상일_경우_절대_날짜로_표시된다`() {
+        val past = now.minusDays(14)
+        val isoString = past.format(DateTimeFormatter.ISO_DATE_TIME)
+        val result = TimeUtils.formatRelativeTime(isoString, now)
+        assertEquals("2026.2.8", result)
     }
 }

--- a/feature/auth/build.gradle.kts
+++ b/feature/auth/build.gradle.kts
@@ -26,6 +26,7 @@ android {
 }
 
 dependencies {
+    implementation(projects.core.analytics)
     implementation(projects.core.common)
     implementation(projects.domain)
     implementation(projects.core.designsystem)

--- a/feature/auth/src/main/java/com/sseotdabwa/buyornot/feature/auth/ui/SplashViewModel.kt
+++ b/feature/auth/src/main/java/com/sseotdabwa/buyornot/feature/auth/ui/SplashViewModel.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import android.util.Log
 import androidx.core.content.pm.PackageInfoCompat
 import androidx.lifecycle.viewModelScope
+import com.sseotdabwa.buyornot.core.analytics.performance.Performance
+import com.sseotdabwa.buyornot.core.analytics.performance.TraceNames
 import com.sseotdabwa.buyornot.core.common.util.runCatchingCancellable
 import com.sseotdabwa.buyornot.core.ui.base.BaseViewModel
 import com.sseotdabwa.buyornot.domain.model.AppUpdateInfo
@@ -66,7 +68,12 @@ class SplashViewModel @Inject constructor(
     private val appUpdateRepository: AppUpdateRepository,
     private val appPreferencesRepository: AppPreferencesRepository,
     private val userRepository: UserRepository,
+    private val performance: Performance,
 ) : BaseViewModel<SplashUiState, SplashIntent, SplashSideEffect>(SplashUiState()) {
+    // 스플래시 진입부터 홈/로그인 분기가 결정되기까지. SPLASH_TIMEOUT_MILLIS 고정 딜레이가
+    // 하한이므로, 이 값이 딜레이를 넘어서면 원격 설정 조회가 병목이라는 뜻이다.
+    private val splashTrace = performance.newTrace(TraceNames.SPLASH_TO_NAVIGATION)
+
     init {
         checkTokenAndNavigate()
     }
@@ -81,6 +88,8 @@ class SplashViewModel @Inject constructor(
         viewModelScope.launch { runCatchingCancellable { userRepository.notifyAppOpened() } }
 
         viewModelScope.launch {
+            splashTrace.start()
+
             // 토큰 체크 + 업데이트 체크 병렬 실행
             val updateInfoDeferred =
                 async {
@@ -107,6 +116,12 @@ class SplashViewModel @Inject constructor(
             val dialogType = determineDialogType(currentVersion, updateInfo)
 
             Log.d(TAG, "currentVersion=$currentVersion, dialogType=$dialogType, updateInfo=$updateInfo")
+
+            // 업데이트 팝업 대기는 사용자 반응 시간이라 지표에서 제외한다 — 여기서 끊어야
+            // splash_to_navigation이 순수하게 앱이 소비한 시간만 담는다.
+            splashTrace.putAttribute("update_dialog", dialogType.toString())
+            splashTrace.putAttribute("has_valid_token", hasValidToken.toString())
+            splashTrace.stop()
 
             if (dialogType != UpdateDialogType.None) {
                 updateState { it.copy(updateDialogType = dialogType) }

--- a/feature/home/src/main/java/com/sseotdabwa/buyornot/feature/home/ui/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/sseotdabwa/buyornot/feature/home/ui/HomeViewModel.kt
@@ -4,6 +4,8 @@ import android.util.Log
 import androidx.lifecycle.viewModelScope
 import com.sseotdabwa.buyornot.core.analytics.Analytics
 import com.sseotdabwa.buyornot.core.analytics.AnalyticsEvent
+import com.sseotdabwa.buyornot.core.analytics.performance.Performance
+import com.sseotdabwa.buyornot.core.analytics.performance.TraceNames
 import com.sseotdabwa.buyornot.core.common.util.TimeUtils
 import com.sseotdabwa.buyornot.core.common.util.runCatchingCancellable
 import com.sseotdabwa.buyornot.core.designsystem.components.ImageAspectRatio
@@ -34,7 +36,13 @@ class HomeViewModel @Inject constructor(
     private val userRepository: UserRepository,
     private val notificationRepository: NotificationRepository,
     private val analytics: Analytics,
+    private val performance: Performance,
 ) : BaseViewModel<HomeUiState, HomeIntent, HomeSideEffect>(HomeUiState()) {
+    // 최초 피드 로딩 구간만 계측한다. loadFeeds()는 로그인 상태에서 init과
+    // userPreferences collect 양쪽에서 겹쳐 호출되므로, 중복 start/stop을 흘려보내는
+    // SingleShotPerfTrace에 의존해 첫 구간만 남긴다.
+    private val feedFirstLoadTrace = performance.newTrace(TraceNames.FEED_FIRST_LOAD)
+
     private var currentUserId: Long? = null
     private var isUserIdLoaded = false
     private var unreadCountJob: Job? = null
@@ -319,12 +327,23 @@ class HomeViewModel @Inject constructor(
         viewModelScope.launch {
             val choice = if (optionIndex == 0) VoteChoice.YES else VoteChoice.NO
 
+            // UI는 위에서 낙관적으로 이미 갱신됐으므로, 이 trace는 사용자 체감 시간이 아닌
+            // 서버 왕복 시간을 재고 롤백이 얼마나 늦게 발생하는지 보기 위한 것이다.
+            val voteTrace =
+                performance.newTrace(TraceNames.VOTE_REQUEST).apply {
+                    putAttribute("user_type", uiState.value.userType.name)
+                    putAttribute("choice", choice.name)
+                    start()
+                }
+
             runCatchingCancellable {
                 when (uiState.value.userType) {
                     UserType.SOCIAL -> feedRepository.voteFeed(feedId.toLong(), choice)
                     UserType.GUEST -> feedRepository.voteGuestFeed(feedId.toLong(), choice)
                 }
             }.onSuccess { voteResult ->
+                voteTrace.putAttribute("result", "success")
+                voteTrace.stop()
                 // 2. 최종 업데이트: 서버 응답으로 확정
                 updateState { state ->
                     val newAllFeeds =
@@ -357,6 +376,8 @@ class HomeViewModel @Inject constructor(
                     ),
                 )
             }.onFailure { e ->
+                voteTrace.putAttribute("result", "error")
+                voteTrace.stop()
                 Log.e("HomeViewModel", "Failed to vote feed: $feedId", e)
                 // 3. 롤백 (Rollback): 해당 피드만 원복, 나머지 동시 변경사항 보존
                 updateState { state ->
@@ -516,6 +537,7 @@ class HomeViewModel @Inject constructor(
         // 새 로드 컨텍스트 시작 → 진행 중이던 페이지네이션 응답 무효화
         feedGeneration++
         viewModelScope.launch {
+            feedFirstLoadTrace.start()
             if (clearFeeds) {
                 updateState {
                     it.copy(
@@ -562,9 +584,14 @@ class HomeViewModel @Inject constructor(
                         nextCursor = feedList.nextCursor,
                     )
                 }
+                feedFirstLoadTrace.putAttribute("result", "success")
+                feedFirstLoadTrace.putMetric("feed_count", newFeeds.size.toLong())
+                feedFirstLoadTrace.stop()
             }.onFailure { e ->
                 Log.e("HomeViewModel", "Failed to load feeds", e)
                 updateState { it.copy(isLoading = false, hasError = true) }
+                feedFirstLoadTrace.putAttribute("result", "error")
+                feedFirstLoadTrace.stop()
             }
         }
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -52,6 +52,7 @@ firebaseBom = "34.9.0"
 googleServices = "4.5.0"
 firebaseCrashlytics = "3.0.7"
 firebaseAppDistribution = "5.3.0"
+firebasePerf = "2.0.2"
 
 # Code Quality
 ktlint = "14.2.0"
@@ -133,6 +134,7 @@ firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.r
 firebase-messaging = { group = "com.google.firebase", name = "firebase-messaging" }
 firebase-crashlytics = { group = "com.google.firebase", name = "firebase-crashlytics" }
 firebase-config = { group = "com.google.firebase", name = "firebase-config" }
+firebase-performance = { group = "com.google.firebase", name = "firebase-perf" }
 
 lottie-compose = { group = "com.airbnb.android", name = "lottie-compose", version.ref = "lottie" }
 
@@ -155,3 +157,4 @@ ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }
 google-services = { id = "com.google.gms.google-services", version.ref = "googleServices" }
 firebase-crashlytics = { id = "com.google.firebase.crashlytics", version.ref = "firebaseCrashlytics" }
 firebase-appdistribution = { id = "com.google.firebase.appdistribution", version.ref = "firebaseAppDistribution" }
+firebase-perf = { id = "com.google.firebase.firebase-perf", version.ref = "firebasePerf" }


### PR DESCRIPTION
## 🛠 Related issue
closed #134

어떤 변경사항이 있었나요?
- [ ] 🐞 BugFix Something isn't working
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [ ] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [x] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (Junit, etc.)

## ✅ CheckPoint
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 컨벤션에 맞게 작성했습니다. (필수)
- [x] merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕) (필수)
- [x] Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다. (필수)
- [ ] BugFix의 경우, 버그의 원인을 파악하였습니다. (선택)

## ✏️ Work Description
Firebase Performance Monitoring을 붙여 dev / prod 성능 지표를 수집합니다.

**1. Gradle 세팅**
- `firebase-perf` 플러그인 `2.0.2` + BOM(`34.9.0`) 하위 `firebase-perf` 라이브러리 추가
- 루트에 `apply false` 선언, `:app`에 플러그인·의존성 적용
- dev(debug) 빌드는 `app/src/debug/AndroidManifest.xml`에 `firebase_performance_logcat_enabled=true` → `adb logcat -s FirebasePerformance`로 로컬 확인 가능

**2. Performance 추상화 (`core/analytics`)**
기존 `Analytics` 인터페이스 패턴을 따라 feature 모듈이 Firebase에 직접 의존하지 않도록 계층을 뒀습니다.
- `Performance` / `PerfTrace` 인터페이스 + `TraceNames` 상수
- `FirebasePerformanceTracer` (internal) — 유일한 구현, Hilt `PerformanceModule`에서 주입
- `SingleShotPerfTrace` 데코레이터 — 중복 `start`, `start` 없는 `stop`, 종료 후 속성 추가를 무시

**3. 커스텀 Trace 3개**
| Trace | 구간 | 속성 / 측정항목 |
|---|---|---|
| `splash_to_navigation` | 스플래시 진입 → 홈/로그인 분기 결정 | `update_dialog`, `has_valid_token` |
| `feed_first_load` | 홈 피드 최초 로딩 시작 → 목록 반영 | `result`, `feed_count` |
| `vote_request` | 투표 요청 왕복 | `user_type`, `choice`, `result` |

## 😅 Uncompleted Tasks
- [ ] Firebase 콘솔에서 dev / prod 앱 각각 데이터 수신 검증 — 콘솔 반영에 최대 12시간 걸려 머지 후 확인 필요

## 📢 To Reviewers

**AGP 9 호환성** — perf 플러그인은 ASM 바이트코드 계측을 쓰기 때문에 AGP 9 마이그레이션(#130) 직후라 가장 걱정한 부분인데, `assembleDebug` / `assembleRelease` 모두 정상 빌드됩니다. release는 R8이 켜져 있어 난독화 빌드도 함께 확인했습니다.

**dev 데이터도 콘솔로 보냅니다** — debug 빌드는 `com.sseotdabwa.buyornot.dev`로 동일 Firebase 프로젝트에 별도 앱으로 등록돼 있어 콘솔에서 환경이 구분됩니다. 이슈 목표가 dev/prod 양쪽 모니터링이라 debug 수집을 끄지 않았습니다. dev 노이즈가 거슬리면 알려주세요.

**설계상 판단 두 가지 봐주세요**
1. `splash_to_navigation`은 업데이트 팝업 **대기 앞에서** 끊었습니다. 팝업 대기는 사용자 반응 시간이라 지표에 섞이면 앱이 소비한 시간을 알 수 없어서입니다. 대신 고정 딜레이 `SPLASH_TIMEOUT_MILLIS(2300ms)`는 포함되므로 이 값이 하한입니다 — 2300ms를 넘는 구간이 보이면 원격 설정 조회가 병목이라는 신호로 쓸 수 있습니다.
2. `feed_first_load`는 `loadFeeds()`가 로그인 상태에서 `init` 경로와 `userPreferences` collect 경로 양쪽에서 겹쳐 호출되는 걸 `SingleShotPerfTrace`로 막고 있습니다. 계측 대상은 "첫 start → 첫 완료"이고, 탭·필터 변경 재로딩은 잡히지 않습니다.

**자동 수집은 별도 코드 없이 동작합니다** — `app_start`, 화면 렌더링(느린/멈춘 프레임), OkHttp 네트워크 요청은 플러그인이 계측하므로 interceptor를 따로 추가하지 않았습니다.

**검증** — `assembleDebug`, `assembleRelease`, `:core:analytics:testDebugUnitTest`(6개 통과), `:feature:auth:testDebugUnitTest`(12개 통과), 전체 `ktlintCheck` 통과. `SingleShotPerfTrace`는 중복 start / start 없는 stop / 종료 후 속성 추가 케이스를 커버합니다.

## 🔧 곁들여 고친 것 — 낡은 TimeUtilsTest + CI 유닛테스트 스텝

작업 중 develop이 이미 깨져 있는 걸 발견해 이 PR에서 함께 고쳤습니다.

```
TimeUtilsTest > 7일을 초과할 경우 절대 날짜로 표시된다 FAILED
    java.lang.AssertionError at TimeUtilsTest.kt:56
```

**원인** — 테스트가 낡았습니다. 구현/테스트 중 어느 쪽이 옳은지 히스토리로 확정했습니다.

| 시점 | 구현 | 8일 전 결과 |
|---|---|---|
| `#36` (테스트 작성) | `days == 7L -> "1주 전"` | 절대 날짜 ← 테스트는 **당시 옳았음** |
| `#37` (TimeUtils 재구현) | `days in 7..13 -> "1주 전"` | `"1주 전"` |

`#37`이 "1주 전" 구간을 7~13일로 넓히고 KDoc의 정책 주석까지 갱신했는데(`7일 이상 14일 미만: '1주 전'`) 테스트를 함께 고치지 않았습니다. `now`가 `LocalDateTime.of(2026, 2, 22, ...)` 고정값이라 시점과 무관하게 **항상** 실패하는 상태였습니다.

KDoc에 명시된 정책이 의도된 동작이라 판단해 **테스트를 정책의 실제 경계에 맞췄습니다.** 깨진 케이스를 지우는 대신 경계를 둘로 나눠 덮었습니다.
- 8일 전 → `"1주 전"` (잘못 잡혀 있던 경계)
- 14일 전 → `"2026.2.8"` (절대 날짜로 넘어가는 진짜 경계, 새로 추가)

**CI에 `unit-test` job 추가** — 이 실패가 5개월간 방치된 근본 원인은 CI가 `ktlintCheck`만 돌린 것입니다. 기존 `ktlint` job에는 실패 시 `ktlintFormat` 후 자동 커밋·푸시하는 흐름이 있어 거기에 테스트를 끼우면 그 순서를 건드리게 되므로, 별도 job으로 분리했습니다. 실패 시 테스트 리포트를 artifact로 올립니다.

이제 저장소 전체 `testDebugUnitTest`(13개 모듈) + `ktlintCheck`가 통과합니다.

> 참고: `TimeUtilsTest`에 제가 추가/수정한 두 테스트는 함수명 공백을 `_`로 썼고 기존 5개는 공백을 그대로 씁니다. 한 파일 안에서 스타일이 섞였으니, 통일을 원하시면 맞추겠습니다.

## 📃 RCA 룰
- R: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
- C: 웬만하면 반영해 주세요. (Comment)
- A: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **성능 개선**
  - 앱 시작, 피드 최초 로딩, 투표 요청의 성능 측정을 추가해 앱 반응성 개선에 활용할 수 있습니다.
  - 성능 측정이 중복 기록되지 않도록 보완했습니다.
  - 디버그 환경에서 성능 측정 결과를 확인할 수 있습니다.

- **버그 수정**
  - 8일 초과 14일 미만의 상대 시간이 “1주 전”으로 표시됩니다.
  - 14일 이상 지난 시간은 절대 날짜로 표시됩니다.

- **품질 개선**
  - Android 단위 테스트 자동화와 실패 시 테스트 결과 보관을 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->