### PR TITLE
Feat/#137: Compose 화면별 렌더링 성능 계측 (JankStats + 화면 단위 Trace)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -120,6 +120,7 @@ dependencies {
     implementation(libs.androidx.lifecycle.runtime.compose)
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.navigation.compose)
+    implementation(libs.androidx.metrics.performance)
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.androidx.compose.ui)
     implementation(libs.androidx.compose.ui.graphics)

--- a/app/src/main/java/com/sseotdabwa/buyornot/MainActivity.kt
+++ b/app/src/main/java/com/sseotdabwa/buyornot/MainActivity.kt
@@ -98,7 +98,9 @@ class MainActivity : ComponentActivity() {
         metricsStateHolder = PerformanceMetricsState.getHolderForHierarchy(window.decorView)
         jankStats =
             JankStats.createAndTrack(window) { frameData ->
-                // 매 프레임 실행된다. 카운터 증가만 하고 할당·I/O를 하지 않는다.
+                // API 24+ 에서는 메인 스레드가 아닌 프레임 메트릭스 스레드에서 매 프레임 실행된다.
+                // frameData 는 다음 프레임에 재사용되므로 필요한 값만 즉시 읽고 넘긴다.
+                // 카운터 증가만 하고 할당·I/O를 하지 않는다.
                 screenPerformanceTracker.onFrame(frameData.isJank, frameData.frameDurationUiNanos)
             }
     }

--- a/app/src/main/java/com/sseotdabwa/buyornot/MainActivity.kt
+++ b/app/src/main/java/com/sseotdabwa/buyornot/MainActivity.kt
@@ -10,15 +10,24 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.runtime.getValue
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.metrics.performance.JankStats
+import androidx.metrics.performance.PerformanceMetricsState
 import com.sseotdabwa.buyornot.core.analytics.Analytics
 import com.sseotdabwa.buyornot.core.analytics.AnalyticsEvent
+import com.sseotdabwa.buyornot.core.analytics.performance.Performance
 import com.sseotdabwa.buyornot.core.designsystem.theme.BuyOrNotTheme
 import com.sseotdabwa.buyornot.core.network.AuthEventBus
+import com.sseotdabwa.buyornot.feature.auth.navigation.SplashRoute
 import com.sseotdabwa.buyornot.notification.FcmKeys
+import com.sseotdabwa.buyornot.performance.ScreenPerformanceTracker
+import com.sseotdabwa.buyornot.performance.screenTraceNameOf
 import com.sseotdabwa.buyornot.ui.BuyOrNotApp
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.MutableStateFlow
 import javax.inject.Inject
+
+/** JankStats 프레임에 붙이는 상태 키. 이 태그로 프레임을 화면별로 가른다. */
+private const val FRAME_STATE_SCREEN = "screen"
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
@@ -28,13 +37,27 @@ class MainActivity : ComponentActivity() {
     @Inject
     lateinit var analytics: Analytics
 
+    @Inject
+    lateinit var performance: Performance
+
     private val pendingFeedDeepLink = MutableStateFlow<PendingFeedDeepLink?>(null)
+
+    private var jankStats: JankStats? = null
+    private var metricsStateHolder: PerformanceMetricsState.Holder? = null
+    private lateinit var screenPerformanceTracker: ScreenPerformanceTracker
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         // 딥링크 처리가 feedId extra를 소비하므로 로깅을 먼저 수행한다.
         handlePushOpened(intent)
         handleFeedDeepLink(intent)
+        screenPerformanceTracker =
+            ScreenPerformanceTracker(
+                performance = performance,
+                // 스플래시가 그려진 것은 "앱을 쓸 수 있는 상태"가 아니므로 TTFD 판정에서 제외한다.
+                nonMeaningfulScreens = setOfNotNull(screenTraceNameOf(SplashRoute::class.qualifiedName)),
+                onScreenChanged = { screen -> metricsStateHolder?.state?.putState(FRAME_STATE_SCREEN, screen) },
+            )
         enableEdgeToEdge(
             statusBarStyle =
                 SystemBarStyle.light(
@@ -52,6 +75,7 @@ class MainActivity : ComponentActivity() {
             BuyOrNotTheme {
                 BuyOrNotApp(
                     authEventBus = authEventBus,
+                    screenPerformanceTracker = screenPerformanceTracker,
                     pendingFeedDeepLink = pendingDeepLink,
                     onPendingFeedDeepLinkConsumed = { pendingFeedDeepLink.value = null },
                     onBackPressed = { finish() },
@@ -59,6 +83,37 @@ class MainActivity : ComponentActivity() {
                 )
             }
         }
+        startTrackingFrames()
+    }
+
+    /**
+     * 프레임 품질 수집을 시작한다.
+     *
+     * 단일 Activity라 JankStats 인스턴스도 하나다. 화면 구분은 프레임에 붙는
+     * [FRAME_STATE_SCREEN] 태그로 하며, 태그는 네비게이션 변경 시 갱신된다.
+     *
+     * `setContent` 이후에 호출해야 [PerformanceMetricsState] 가 붙을 뷰 계층이 존재한다.
+     */
+    private fun startTrackingFrames() {
+        metricsStateHolder = PerformanceMetricsState.getHolderForHierarchy(window.decorView)
+        jankStats =
+            JankStats.createAndTrack(window) { frameData ->
+                // 매 프레임 실행된다. 카운터 증가만 하고 할당·I/O를 하지 않는다.
+                screenPerformanceTracker.onFrame(frameData.isJank, frameData.frameDurationUiNanos)
+            }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        jankStats?.isTrackingEnabled = true
+        screenPerformanceTracker.onResumed()
+    }
+
+    override fun onPause() {
+        super.onPause()
+        jankStats?.isTrackingEnabled = false
+        // 백그라운드 시간이 화면 체류 시간으로 잡히지 않도록 구간을 끊는다.
+        screenPerformanceTracker.onPaused()
     }
 
     override fun onNewIntent(intent: Intent) {

--- a/app/src/main/java/com/sseotdabwa/buyornot/performance/ScreenPerformanceTracker.kt
+++ b/app/src/main/java/com/sseotdabwa/buyornot/performance/ScreenPerformanceTracker.kt
@@ -1,0 +1,111 @@
+package com.sseotdabwa.buyornot.performance
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import com.sseotdabwa.buyornot.core.analytics.performance.PerfTrace
+import com.sseotdabwa.buyornot.core.analytics.performance.Performance
+import com.sseotdabwa.buyornot.core.analytics.performance.ScreenFrameStats
+import com.sseotdabwa.buyornot.core.analytics.performance.TraceNames
+
+/**
+ * 단일 Activity Compose 구조에서 화면 단위 성능 지표를 만든다.
+ *
+ * Firebase 자동 화면 Trace는 Activity/Fragment 단위라 이 앱에서는 `_st_MainActivity`
+ * 하나로 모든 화면의 프레임이 뭉개진다. 그래서 두 지표를 직접 만든다.
+ * - `screen_render_<화면>` — 화면 진입부터 콘텐츠 첫 프레임까지
+ * - `screen_frames_<화면>` — 체류 구간 길이 + 프레임 품질(전체/jank/frozen)
+ *
+ * 메인 스레드에서만 접근한다. 프레임 콜백과 네비게이션 변경이 모두 메인 스레드다.
+ *
+ * @param nonMeaningfulScreens 앱 시작 TTFD 판정에서 제외할 화면. 스플래시가 그려진 것은
+ *   "앱을 쓸 수 있는 상태"가 아니므로 제외한다.
+ */
+class ScreenPerformanceTracker(
+    private val performance: Performance,
+    private val nonMeaningfulScreens: Set<String> = emptySet(),
+    private val onScreenChanged: (String) -> Unit = {},
+) {
+    /** 스플래시가 아닌 첫 화면의 콘텐츠가 그려졌는지. 앱 시작 TTFD 보고 조건으로 쓴다. */
+    var isFirstMeaningfulRenderDone: Boolean by mutableStateOf(false)
+        private set
+
+    private var currentScreen: String? = null
+    private var renderTrace: PerfTrace? = null
+    private var framesTrace: PerfTrace? = null
+    private val frameStats = ScreenFrameStats()
+
+    fun onScreenEntered(screen: String) {
+        if (screen == currentScreen) return
+
+        stopFramesTrace()
+        abandonRenderTrace()
+
+        currentScreen = screen
+        onScreenChanged(screen)
+        renderTrace = performance.newTrace(TraceNames.screenRender(screen)).apply { start() }
+        startFramesTrace(screen)
+    }
+
+    /** [com.sseotdabwa.buyornot.core.ui.performance.ReportScreenRendered] 가 첫 프레임에서 호출한다. */
+    fun onScreenContentRendered() {
+        val screen = currentScreen ?: return
+
+        renderTrace?.stop()
+        renderTrace = null
+        if (screen !in nonMeaningfulScreens) isFirstMeaningfulRenderDone = true
+    }
+
+    fun onFrame(
+        isJank: Boolean,
+        frameDurationNanos: Long,
+    ) {
+        if (currentScreen == null) return
+        frameStats.record(isJank, frameDurationNanos)
+    }
+
+    /**
+     * 백그라운드 진입 시 호출. 체류 시간이 백그라운드 시간까지 삼키지 않도록 구간을 끊는다.
+     * [currentScreen] 은 유지해 [onResumed] 에서 이어받는다.
+     */
+    fun onPaused() {
+        stopFramesTrace()
+        abandonRenderTrace()
+    }
+
+    fun onResumed() {
+        val screen = currentScreen ?: return
+        startFramesTrace(screen)
+    }
+
+    private fun startFramesTrace(screen: String) {
+        frameStats.reset()
+        framesTrace = performance.newTrace(TraceNames.screenFrames(screen)).apply { start() }
+    }
+
+    private fun stopFramesTrace() {
+        val trace = framesTrace ?: return
+        framesTrace = null
+        // 프레임이 한 장도 없으면(즉시 스쳐 지나간 화면) 0으로 평균을 흐리지 않도록 버린다.
+        if (frameStats.isEmpty) return
+
+        trace.putMetric(METRIC_TOTAL_FRAMES, frameStats.totalFrames)
+        trace.putMetric(METRIC_JANK_FRAMES, frameStats.jankFrames)
+        trace.putMetric(METRIC_FROZEN_FRAMES, frameStats.frozenFrames)
+        trace.stop()
+    }
+
+    /**
+     * 콘텐츠 첫 프레임 전에 이탈했거나 백그라운드로 갔으면 stop 하지 않고 버린다.
+     * Firebase는 stop 되지 않은 Trace를 보고하지 않으므로, 미완성 구간이 지표를 오염시키지 않는다.
+     */
+    private fun abandonRenderTrace() {
+        renderTrace = null
+    }
+
+    private companion object {
+        const val METRIC_TOTAL_FRAMES = "total_frames"
+        const val METRIC_JANK_FRAMES = "jank_frames"
+        const val METRIC_FROZEN_FRAMES = "frozen_frames"
+    }
+}

--- a/app/src/main/java/com/sseotdabwa/buyornot/performance/ScreenPerformanceTracker.kt
+++ b/app/src/main/java/com/sseotdabwa/buyornot/performance/ScreenPerformanceTracker.kt
@@ -16,7 +16,9 @@ import com.sseotdabwa.buyornot.core.analytics.performance.TraceNames
  * - `screen_render_<화면>` — 화면 진입부터 콘텐츠 첫 프레임까지
  * - `screen_frames_<화면>` — 체류 구간 길이 + 프레임 품질(전체/jank/frozen)
  *
- * 메인 스레드에서만 접근한다. 프레임 콜백과 네비게이션 변경이 모두 메인 스레드다.
+ * [onFrame] 만 JankStats 의 프레임 메트릭스 스레드에서 호출되고(API 24+), 나머지는 모두
+ * 메인 스레드에서 호출된다. 두 스레드가 공유하는 상태는 [currentScreen] 과 [frameStats] 뿐이라
+ * 각각 `@Volatile` 과 내부 락으로 막는다. Trace 핸들은 메인 스레드에서만 만지므로 보호하지 않는다.
  *
  * @param nonMeaningfulScreens 앱 시작 TTFD 판정에서 제외할 화면. 스플래시가 그려진 것은
  *   "앱을 쓸 수 있는 상태"가 아니므로 제외한다.
@@ -30,6 +32,8 @@ class ScreenPerformanceTracker(
     var isFirstMeaningfulRenderDone: Boolean by mutableStateOf(false)
         private set
 
+    /** [onFrame] 이 프레임 메트릭스 스레드에서 읽으므로 쓰기가 곧바로 보이도록 한다. */
+    @Volatile
     private var currentScreen: String? = null
     private var renderTrace: PerfTrace? = null
     private var framesTrace: PerfTrace? = null
@@ -86,12 +90,13 @@ class ScreenPerformanceTracker(
     private fun stopFramesTrace() {
         val trace = framesTrace ?: return
         framesTrace = null
+        val stats = frameStats.snapshot()
         // 프레임이 한 장도 없으면(즉시 스쳐 지나간 화면) 0으로 평균을 흐리지 않도록 버린다.
-        if (frameStats.isEmpty) return
+        if (stats.isEmpty) return
 
-        trace.putMetric(METRIC_TOTAL_FRAMES, frameStats.totalFrames)
-        trace.putMetric(METRIC_JANK_FRAMES, frameStats.jankFrames)
-        trace.putMetric(METRIC_FROZEN_FRAMES, frameStats.frozenFrames)
+        trace.putMetric(METRIC_TOTAL_FRAMES, stats.totalFrames)
+        trace.putMetric(METRIC_JANK_FRAMES, stats.jankFrames)
+        trace.putMetric(METRIC_FROZEN_FRAMES, stats.frozenFrames)
         trace.stop()
     }
 

--- a/app/src/main/java/com/sseotdabwa/buyornot/performance/ScreenPerformanceTracker.kt
+++ b/app/src/main/java/com/sseotdabwa/buyornot/performance/ScreenPerformanceTracker.kt
@@ -35,17 +35,33 @@ class ScreenPerformanceTracker(
     /** [onFrame] 이 프레임 메트릭스 스레드에서 읽으므로 쓰기가 곧바로 보이도록 한다. */
     @Volatile
     private var currentScreen: String? = null
+
+    /** 지금 측정 중인 체류 구간의 식별자. 같은 화면 종류의 연속 진입을 가르는 기준이다. */
+    private var currentSessionId: String? = null
     private var renderTrace: PerfTrace? = null
     private var framesTrace: PerfTrace? = null
     private val frameStats = ScreenFrameStats()
 
-    fun onScreenEntered(screen: String) {
-        if (screen == currentScreen) return
+    /**
+     * 화면 진입. 이전 구간을 닫고 새 구간을 연다.
+     *
+     * @param screen Trace 이름에 실을 화면 이름. 고유 Trace 이름 수를 화면 종류만큼으로 묶기 위해
+     *   route 인자를 접은 값이라, 서로 다른 진입이 같은 이름을 가질 수 있다.
+     * @param sessionId 이 진입을 구분하는 식별자. `NavBackStackEntry.id` 를 넘긴다.
+     *   [screen] 으로 구분하면 피드 A 상세 → 피드 B 상세처럼 이름이 같은 연속 진입이
+     *   같은 구간으로 뭉개져, B의 렌더 Trace가 아예 열리지 않고 B의 프레임이 A의 집계로 들어간다.
+     */
+    fun onScreenEntered(
+        screen: String,
+        sessionId: String,
+    ) {
+        if (sessionId == currentSessionId) return
 
         stopFramesTrace()
         abandonRenderTrace()
 
         currentScreen = screen
+        currentSessionId = sessionId
         onScreenChanged(screen)
         renderTrace = performance.newTrace(TraceNames.screenRender(screen)).apply { start() }
         startFramesTrace(screen)

--- a/app/src/main/java/com/sseotdabwa/buyornot/performance/ScreenTraceName.kt
+++ b/app/src/main/java/com/sseotdabwa/buyornot/performance/ScreenTraceName.kt
@@ -1,0 +1,50 @@
+package com.sseotdabwa.buyornot.performance
+
+/** Trace 이름에 실을 화면 이름의 최대 길이. Firebase Trace 이름 상한(100자)에 접두사 여유를 둔다. */
+private const val MAX_SCREEN_NAME_LENGTH = 60
+
+/**
+ * 네비게이션 route를 Trace 이름에 쓸 짧은 화면 이름으로 바꾼다.
+ *
+ * route를 그대로 쓸 수 없는 이유:
+ * - 타입 안전 네비게이션의 route는 fully-qualified 클래스명이라 지나치게 길다.
+ * - 일부 route는 인자를 갖는다(`....FeedDetailRoute/{feedId}`). 인자를 남기면 고유 Trace
+ *   이름 수가 무한히 늘어나는데, Firebase는 고유 이름 수에 상한이 있다.
+ *
+ * 인자를 제거하고 클래스 단순명만 남겨 **화면 종류 수만큼으로 bounded** 하게 유지한다.
+ * 연속 대문자(약어)는 글자별로 끊긴다 — `FAQRoute` → `f_a_q`. 정확도보다 안정성이 목적이다.
+ */
+internal fun screenTraceNameOf(route: String?): String? {
+    if (route.isNullOrBlank()) return null
+
+    val withoutArguments =
+        route
+            .substringBefore('/')
+            .substringBefore('?')
+    val simpleName = withoutArguments.substringAfterLast('.')
+    val screenName =
+        simpleName
+            .removeSuffix("Route")
+            .camelToSnakeCase()
+            .take(MAX_SCREEN_NAME_LENGTH)
+            .trim('_')
+
+    return screenName.ifBlank { null }
+}
+
+private fun String.camelToSnakeCase(): String =
+    buildString {
+        this@camelToSnakeCase.forEach { char ->
+            when {
+                char.isUpperCase() -> {
+                    if (isNotEmpty() && last() != '_') append('_')
+                    append(char.lowercaseChar())
+                }
+
+                char.isLetterOrDigit() -> append(char)
+
+                // Firebase Trace 이름에 쓸 수 없는 문자는 구분자로 접는다.
+                else -> if (isNotEmpty() && last() != '_') append('_')
+            }
+        }
+    }.trim('_')

--- a/app/src/main/java/com/sseotdabwa/buyornot/ui/BuyOrNotApp.kt
+++ b/app/src/main/java/com/sseotdabwa/buyornot/ui/BuyOrNotApp.kt
@@ -1,6 +1,7 @@
 package com.sseotdabwa.buyornot.ui
 
 import androidx.activity.compose.BackHandler
+import androidx.activity.compose.ReportDrawnWhen
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.padding
@@ -9,6 +10,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -18,6 +20,8 @@ import com.sseotdabwa.buyornot.PendingFeedDeepLink
 import com.sseotdabwa.buyornot.core.designsystem.components.BuyOrNotSnackBarHost
 import com.sseotdabwa.buyornot.core.designsystem.theme.BuyOrNotTheme
 import com.sseotdabwa.buyornot.core.network.AuthEventBus
+import com.sseotdabwa.buyornot.core.ui.performance.LocalScreenRenderReporter
+import com.sseotdabwa.buyornot.core.ui.performance.ScreenRenderReporter
 import com.sseotdabwa.buyornot.core.ui.permission.rememberNotificationPermission
 import com.sseotdabwa.buyornot.core.ui.snackbar.LocalSnackbarState
 import com.sseotdabwa.buyornot.core.ui.snackbar.rememberBuyOrNotSnackbarState
@@ -26,10 +30,13 @@ import com.sseotdabwa.buyornot.feature.auth.navigation.SplashRoute
 import com.sseotdabwa.buyornot.feature.home.navigation.HomeRoute
 import com.sseotdabwa.buyornot.feature.notification.navigation.navigateToFeedDetail
 import com.sseotdabwa.buyornot.navigation.BuyOrNotNavHost
+import com.sseotdabwa.buyornot.performance.ScreenPerformanceTracker
+import com.sseotdabwa.buyornot.performance.screenTraceNameOf
 
 @Composable
 fun BuyOrNotApp(
     authEventBus: AuthEventBus,
+    screenPerformanceTracker: ScreenPerformanceTracker,
     pendingFeedDeepLink: PendingFeedDeepLink? = null,
     onPendingFeedDeepLinkConsumed: () -> Unit = {},
     onBackPressed: () -> Unit = {},
@@ -77,7 +84,26 @@ fun BuyOrNotApp(
             route == SplashRoute::class.qualifiedName || route == AuthRoute::class.qualifiedName
         }
 
-    CompositionLocalProvider(LocalSnackbarState provides snackbarState) {
+    // 화면별 렌더링 지표. route에는 패키지 경로와 인자가 섞여 있어 짧은 이름으로 접어서 쓴다.
+    val screenName = remember(currentRoute) { screenTraceNameOf(currentRoute) }
+    LaunchedEffect(screenName) {
+        screenName?.let(screenPerformanceTracker::onScreenEntered)
+    }
+
+    // 스플래시가 아닌 첫 화면의 콘텐츠가 그려진 시점을 앱 시작 TTFD로 보고한다.
+    // Firebase `_app_start`는 Activity onResume에서 끝나 Compose 첫 프레임 전이므로 체감 시간을
+    // 과소보고한다. reportFullyDrawn()은 Activity당 한 번만 유효해 화면 전환에는 쓸 수 없다.
+    ReportDrawnWhen { screenPerformanceTracker.isFirstMeaningfulRenderDone }
+
+    val screenRenderReporter =
+        remember(screenPerformanceTracker) {
+            ScreenRenderReporter { screenPerformanceTracker.onScreenContentRendered() }
+        }
+
+    CompositionLocalProvider(
+        LocalSnackbarState provides snackbarState,
+        LocalScreenRenderReporter provides screenRenderReporter,
+    ) {
         Scaffold(
             containerColor = BuyOrNotTheme.colors.gray0,
             snackbarHost = { BuyOrNotSnackBarHost(snackbarState.snackbarHostState) },

--- a/app/src/main/java/com/sseotdabwa/buyornot/ui/BuyOrNotApp.kt
+++ b/app/src/main/java/com/sseotdabwa/buyornot/ui/BuyOrNotApp.kt
@@ -84,10 +84,17 @@ fun BuyOrNotApp(
             route == SplashRoute::class.qualifiedName || route == AuthRoute::class.qualifiedName
         }
 
-    // 화면별 렌더링 지표. route에는 패키지 경로와 인자가 섞여 있어 짧은 이름으로 접어서 쓴다.
+    // 화면별 렌더링 지표. route에는 패키지 경로와 인자 자리표시자가 섞여 있어 짧은 이름으로 접어서 쓴다.
+    //
+    // 체류 구간은 이름이 아니라 back stack entry로 가른다. route는 인자가 채워지지 않은 패턴
+    // (`...NotificationDetailRoute/{feedId}/{notificationId}`)이라 피드 A 상세와 B 상세가
+    // 완전히 같은 문자열이다. 이름을 기준으로 삼으면 A → B 진입에서 B의 Trace가 열리지 않는다.
     val screenName = remember(currentRoute) { screenTraceNameOf(currentRoute) }
-    LaunchedEffect(screenName) {
-        screenName?.let(screenPerformanceTracker::onScreenEntered)
+    val screenSessionId = navBackStackEntry?.id
+    LaunchedEffect(screenSessionId, screenName) {
+        val screen = screenName ?: return@LaunchedEffect
+        val sessionId = screenSessionId ?: return@LaunchedEffect
+        screenPerformanceTracker.onScreenEntered(screen = screen, sessionId = sessionId)
     }
 
     // 스플래시가 아닌 첫 화면의 콘텐츠가 그려진 시점을 앱 시작 TTFD로 보고한다.

--- a/app/src/test/java/com/sseotdabwa/buyornot/performance/ScreenPerformanceTrackerTest.kt
+++ b/app/src/test/java/com/sseotdabwa/buyornot/performance/ScreenPerformanceTrackerTest.kt
@@ -1,0 +1,159 @@
+package com.sseotdabwa.buyornot.performance
+
+import com.sseotdabwa.buyornot.core.analytics.performance.PerfTrace
+import com.sseotdabwa.buyornot.core.analytics.performance.Performance
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ScreenPerformanceTrackerTest {
+    private val performance = FakePerformance()
+    private val tracker =
+        ScreenPerformanceTracker(
+            performance = performance,
+            nonMeaningfulScreens = setOf(SPLASH),
+        )
+
+    private fun renderTracesOf(screen: String) = performance.tracesNamed("screen_render_$screen")
+
+    private fun framesTracesOf(screen: String) = performance.tracesNamed("screen_frames_$screen")
+
+    @Test
+    fun `화면에_진입하면_render와_frames_Trace를_함께_시작한다`() {
+        tracker.onScreenEntered(screen = HOME, sessionId = "entry-1")
+
+        assertEquals(1, renderTracesOf(HOME).size)
+        assertEquals(1, framesTracesOf(HOME).size)
+        assertTrue(performance.traces.all { it.started })
+    }
+
+    /**
+     * route는 인자가 채워지지 않은 패턴이라 피드 A 상세와 B 상세의 화면 이름이 같다.
+     * 이름으로 구간을 가르면 B의 Trace가 아예 열리지 않는다.
+     */
+    @Test
+    fun `이름이_같아도_back_stack_entry가_다르면_새_render_Trace를_연다`() {
+        tracker.onScreenEntered(screen = DETAIL, sessionId = "entry-1")
+        tracker.onScreenContentRendered()
+
+        tracker.onScreenEntered(screen = DETAIL, sessionId = "entry-2")
+        tracker.onScreenContentRendered()
+
+        val renderTraces = renderTracesOf(DETAIL)
+        assertEquals(2, renderTraces.size)
+        assertTrue(renderTraces.all { it.stopped })
+    }
+
+    @Test
+    fun `같은_back_stack_entry로_다시_호출하면_구간을_새로_열지_않는다`() {
+        tracker.onScreenEntered(screen = HOME, sessionId = "entry-1")
+        tracker.onScreenEntered(screen = HOME, sessionId = "entry-1")
+
+        assertEquals(1, renderTracesOf(HOME).size)
+        assertEquals(1, framesTracesOf(HOME).size)
+    }
+
+    @Test
+    fun `이름이_같은_연속_진입의_프레임_집계는_섞이지_않는다`() {
+        tracker.onScreenEntered(screen = DETAIL, sessionId = "entry-1")
+        repeat(3) { tracker.onFrame(isJank = true, frameDurationNanos = JANK_FRAME) }
+
+        tracker.onScreenEntered(screen = DETAIL, sessionId = "entry-2")
+        tracker.onFrame(isJank = false, frameDurationNanos = SMOOTH_FRAME)
+        tracker.onPaused()
+
+        val framesTraces = framesTracesOf(DETAIL)
+        assertEquals(2, framesTraces.size)
+        assertEquals(3L, framesTraces[0].metrics["total_frames"])
+        assertEquals(3L, framesTraces[0].metrics["jank_frames"])
+        assertEquals(1L, framesTraces[1].metrics["total_frames"])
+        assertEquals(0L, framesTraces[1].metrics["jank_frames"])
+    }
+
+    @Test
+    fun `프레임이_한_장도_없는_구간은_보고하지_않는다`() {
+        tracker.onScreenEntered(screen = HOME, sessionId = "entry-1")
+        tracker.onScreenEntered(screen = DETAIL, sessionId = "entry-2")
+
+        assertFalse(framesTracesOf(HOME).single().stopped)
+    }
+
+    @Test
+    fun `콘텐츠_첫_프레임_전에_이탈하면_render_Trace를_버린다`() {
+        tracker.onScreenEntered(screen = HOME, sessionId = "entry-1")
+        tracker.onScreenEntered(screen = DETAIL, sessionId = "entry-2")
+
+        assertFalse(renderTracesOf(HOME).single().stopped)
+    }
+
+    @Test
+    fun `스플래시가_그려진_것만으로는_TTFD를_보고하지_않는다`() {
+        tracker.onScreenEntered(screen = SPLASH, sessionId = "entry-1")
+        tracker.onScreenContentRendered()
+
+        assertFalse(tracker.isFirstMeaningfulRenderDone)
+    }
+
+    /** 로그인 시작 경로에서는 로그인 화면이 첫 의미 있는 화면이다. */
+    @Test
+    fun `로그인_화면이_그려지면_TTFD를_보고한다`() {
+        tracker.onScreenEntered(screen = SPLASH, sessionId = "entry-1")
+        tracker.onScreenContentRendered()
+
+        tracker.onScreenEntered(screen = AUTH, sessionId = "entry-2")
+        tracker.onScreenContentRendered()
+
+        assertTrue(tracker.isFirstMeaningfulRenderDone)
+    }
+
+    private companion object {
+        const val SPLASH = "splash"
+        const val AUTH = "auth"
+        const val HOME = "home"
+        const val DETAIL = "notification_detail"
+
+        const val SMOOTH_FRAME = 8_000_000L
+        const val JANK_FRAME = 20_000_000L
+    }
+}
+
+private class FakePerformance : Performance {
+    val traces = mutableListOf<FakeTrace>()
+
+    override fun newTrace(name: String): PerfTrace = FakeTrace(name).also { traces += it }
+
+    fun tracesNamed(name: String): List<FakeTrace> = traces.filter { it.name == name }
+}
+
+private class FakeTrace(
+    val name: String,
+) : PerfTrace {
+    var started = false
+        private set
+
+    var stopped = false
+        private set
+
+    val metrics = mutableMapOf<String, Long>()
+
+    override fun start() {
+        started = true
+    }
+
+    override fun stop() {
+        stopped = true
+    }
+
+    override fun putAttribute(
+        name: String,
+        value: String,
+    ) = Unit
+
+    override fun putMetric(
+        name: String,
+        value: Long,
+    ) {
+        metrics[name] = value
+    }
+}

--- a/app/src/test/java/com/sseotdabwa/buyornot/performance/ScreenTraceNameTest.kt
+++ b/app/src/test/java/com/sseotdabwa/buyornot/performance/ScreenTraceNameTest.kt
@@ -1,0 +1,72 @@
+package com.sseotdabwa.buyornot.performance
+
+import com.sseotdabwa.buyornot.core.analytics.performance.TraceNames
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ScreenTraceNameTest {
+    @Test
+    fun `패키지 경로를 벗기고 Route 접미사를 제거한다`() {
+        assertEquals(
+            "home",
+            screenTraceNameOf("com.sseotdabwa.buyornot.feature.home.navigation.HomeRoute"),
+        )
+    }
+
+    @Test
+    fun `여러 단어는 snake_case로 바꾼다`() {
+        assertEquals(
+            "my_page",
+            screenTraceNameOf("com.sseotdabwa.buyornot.feature.mypage.navigation.MyPageRoute"),
+        )
+    }
+
+    @Test
+    fun `경로 인자를 제거해 이름이 인자값마다 갈라지지 않게 한다`() {
+        val name = "com.sseotdabwa.buyornot.feature.notification.navigation.FeedDetailRoute"
+        assertEquals("feed_detail", screenTraceNameOf("$name/{feedId}"))
+        assertEquals("feed_detail", screenTraceNameOf("$name/123"))
+    }
+
+    @Test
+    fun `쿼리 인자도 제거한다`() {
+        assertEquals(
+            "home",
+            screenTraceNameOf("com.sseotdabwa.buyornot.feature.home.navigation.HomeRoute?initialTab={initialTab}"),
+        )
+    }
+
+    @Test
+    fun `Route 접미사가 없어도 처리한다`() {
+        assertEquals("image_viewer", screenTraceNameOf("com.sseotdabwa.buyornot.core.ui.imageviewer.ImageViewer"))
+    }
+
+    @Test
+    fun `이름을 만들 수 없으면 null을 반환한다`() {
+        assertNull(screenTraceNameOf(null))
+        assertNull(screenTraceNameOf(""))
+        assertNull(screenTraceNameOf("   "))
+        assertNull(screenTraceNameOf("Route"))
+    }
+
+    @Test
+    fun `Trace 이름 상한을 넘지 않도록 길이를 자른다`() {
+        val absurdlyLong = "com.example." + "A".repeat(300) + "Route"
+        val name = requireNotNull(screenTraceNameOf(absurdlyLong))
+
+        // Firebase Trace 이름 상한은 100자다. 접두사(`screen_render_`)를 더해도 남아야 한다.
+        assertTrue("length=${name.length}", name.length <= 60)
+        assertTrue(TraceNames.screenRender(name).length <= 100)
+    }
+
+    @Test
+    fun `구분자로 시작하거나 끝나지 않는다`() {
+        val name = requireNotNull(screenTraceNameOf("com.example.UploadRoute"))
+
+        assertFalse(name.startsWith("_"))
+        assertFalse(name.endsWith("_"))
+    }
+}

--- a/app/src/test/java/com/sseotdabwa/buyornot/performance/ScreenTraceNameTest.kt
+++ b/app/src/test/java/com/sseotdabwa/buyornot/performance/ScreenTraceNameTest.kt
@@ -9,7 +9,7 @@ import org.junit.Test
 
 class ScreenTraceNameTest {
     @Test
-    fun `패키지 경로를 벗기고 Route 접미사를 제거한다`() {
+    fun `패키지_경로를_벗기고_Route_접미사를_제거한다`() {
         assertEquals(
             "home",
             screenTraceNameOf("com.sseotdabwa.buyornot.feature.home.navigation.HomeRoute"),
@@ -17,7 +17,7 @@ class ScreenTraceNameTest {
     }
 
     @Test
-    fun `여러 단어는 snake_case로 바꾼다`() {
+    fun `여러_단어는_snake_case로_바꾼다`() {
         assertEquals(
             "my_page",
             screenTraceNameOf("com.sseotdabwa.buyornot.feature.mypage.navigation.MyPageRoute"),
@@ -25,14 +25,14 @@ class ScreenTraceNameTest {
     }
 
     @Test
-    fun `경로 인자를 제거해 이름이 인자값마다 갈라지지 않게 한다`() {
+    fun `경로_인자를_제거해_이름이_인자값마다_갈라지지_않게_한다`() {
         val name = "com.sseotdabwa.buyornot.feature.notification.navigation.FeedDetailRoute"
         assertEquals("feed_detail", screenTraceNameOf("$name/{feedId}"))
         assertEquals("feed_detail", screenTraceNameOf("$name/123"))
     }
 
     @Test
-    fun `쿼리 인자도 제거한다`() {
+    fun `쿼리_인자도_제거한다`() {
         assertEquals(
             "home",
             screenTraceNameOf("com.sseotdabwa.buyornot.feature.home.navigation.HomeRoute?initialTab={initialTab}"),
@@ -40,12 +40,12 @@ class ScreenTraceNameTest {
     }
 
     @Test
-    fun `Route 접미사가 없어도 처리한다`() {
+    fun `Route_접미사가_없어도_처리한다`() {
         assertEquals("image_viewer", screenTraceNameOf("com.sseotdabwa.buyornot.core.ui.imageviewer.ImageViewer"))
     }
 
     @Test
-    fun `이름을 만들 수 없으면 null을 반환한다`() {
+    fun `이름을_만들_수_없으면_null을_반환한다`() {
         assertNull(screenTraceNameOf(null))
         assertNull(screenTraceNameOf(""))
         assertNull(screenTraceNameOf("   "))
@@ -53,7 +53,7 @@ class ScreenTraceNameTest {
     }
 
     @Test
-    fun `Trace 이름 상한을 넘지 않도록 길이를 자른다`() {
+    fun `Trace_이름_상한을_넘지_않도록_길이를_자른다`() {
         val absurdlyLong = "com.example." + "A".repeat(300) + "Route"
         val name = requireNotNull(screenTraceNameOf(absurdlyLong))
 
@@ -63,7 +63,7 @@ class ScreenTraceNameTest {
     }
 
     @Test
-    fun `구분자로 시작하거나 끝나지 않는다`() {
+    fun `구분자로_시작하거나_끝나지_않는다`() {
         val name = requireNotNull(screenTraceNameOf("com.example.UploadRoute"))
 
         assertFalse(name.startsWith("_"))

--- a/core/analytics/src/main/java/com/sseotdabwa/buyornot/core/analytics/performance/Performance.kt
+++ b/core/analytics/src/main/java/com/sseotdabwa/buyornot/core/analytics/performance/Performance.kt
@@ -29,4 +29,20 @@ object TraceNames {
 
     /** 투표 요청 왕복. UI는 낙관적 업데이트라 체감 시간과 분리해 본다. */
     const val VOTE_REQUEST = "vote_request"
+
+    /**
+     * 화면 진입부터 콘텐츠 첫 프레임이 나가기까지 (화면별 TTID/TTFD).
+     *
+     * [screen] 은 route 문자열이 아니라 인자가 제거된 짧은 이름이어야 한다.
+     * Firebase는 고유 Trace 이름 수에 상한이 있어, 파라미터가 섞이면 이름이 무한히 늘어난다.
+     */
+    fun screenRender(screen: String): String = "screen_render_$screen"
+
+    /**
+     * 화면 체류 구간의 프레임 품질. 구간 길이는 체류 시간이고 프레임 수는 측정항목으로 실린다.
+     *
+     * 단일 Activity Compose 구조에서 Firebase 자동 화면 Trace(`_st_MainActivity`)가
+     * 모든 화면의 프레임을 하나로 뭉개는 것을 화면 단위로 분해한 대체 지표다.
+     */
+    fun screenFrames(screen: String): String = "screen_frames_$screen"
 }

--- a/core/analytics/src/main/java/com/sseotdabwa/buyornot/core/analytics/performance/ScreenFrameStats.kt
+++ b/core/analytics/src/main/java/com/sseotdabwa/buyornot/core/analytics/performance/ScreenFrameStats.kt
@@ -3,34 +3,55 @@ package com.sseotdabwa.buyornot.core.analytics.performance
 /**
  * 한 화면에 머무는 동안의 프레임 품질 집계.
  *
- * JankStats 콜백에서 **매 프레임** 호출되므로 [record] 는 할당을 하지 않는다.
- * 메인 스레드에서만 접근한다 — 프레임 콜백과 네비게이션 변경이 모두 메인 스레드다.
+ * [record] 는 JankStats 콜백에서 **매 프레임** 호출된다. 이 콜백은 API 24+ 에서 메인 스레드가
+ * 아니라 플랫폼 FrameMetrics 전용 스레드로 온다. 반면 [snapshot] 과 [reset] 은 네비게이션·
+ * 수명주기를 따라 메인 스레드에서 호출된다. 그래서 모든 접근을 같은 락으로 묶는다.
+ * 두 스레드가 부딪히는 일이 거의 없어 프레임 경로 비용은 무시할 수 있고, [record] 는 할당을 하지 않는다.
  */
 class ScreenFrameStats {
-    var totalFrames: Long = 0L
-        private set
+    private val lock = Any()
 
-    var jankFrames: Long = 0L
-        private set
+    private var totalFrames: Long = 0L
+    private var jankFrames: Long = 0L
+    private var frozenFrames: Long = 0L
 
-    var frozenFrames: Long = 0L
-        private set
-
-    val isEmpty: Boolean get() = totalFrames == 0L
-
+    /**
+     * 프레임 한 장을 센다. JankStats 의 `FrameData` 는 다음 프레임에 재사용되므로
+     * 호출부에서 필요한 값만 뽑아 넘기고, 여기서도 인스턴스를 보관하지 않는다.
+     */
     fun record(
         isJank: Boolean,
         frameDurationNanos: Long,
-    ) {
+    ) = synchronized(lock) {
         totalFrames++
         if (isJank) jankFrames++
         if (frameDurationNanos >= FROZEN_FRAME_THRESHOLD_NANOS) frozenFrames++
     }
 
-    fun reset() {
-        totalFrames = 0L
-        jankFrames = 0L
-        frozenFrames = 0L
+    /** 세 값이 서로 어긋난 시점의 것으로 섞이지 않도록 한 번에 읽는다. */
+    fun snapshot(): Snapshot =
+        synchronized(lock) {
+            Snapshot(
+                totalFrames = totalFrames,
+                jankFrames = jankFrames,
+                frozenFrames = frozenFrames,
+            )
+        }
+
+    fun reset() =
+        synchronized(lock) {
+            totalFrames = 0L
+            jankFrames = 0L
+            frozenFrames = 0L
+        }
+
+    /** [snapshot] 이 뜬 한 시점의 집계. */
+    data class Snapshot(
+        val totalFrames: Long,
+        val jankFrames: Long,
+        val frozenFrames: Long,
+    ) {
+        val isEmpty: Boolean get() = totalFrames == 0L
     }
 
     companion object {

--- a/core/analytics/src/main/java/com/sseotdabwa/buyornot/core/analytics/performance/ScreenFrameStats.kt
+++ b/core/analytics/src/main/java/com/sseotdabwa/buyornot/core/analytics/performance/ScreenFrameStats.kt
@@ -1,0 +1,40 @@
+package com.sseotdabwa.buyornot.core.analytics.performance
+
+/**
+ * 한 화면에 머무는 동안의 프레임 품질 집계.
+ *
+ * JankStats 콜백에서 **매 프레임** 호출되므로 [record] 는 할당을 하지 않는다.
+ * 메인 스레드에서만 접근한다 — 프레임 콜백과 네비게이션 변경이 모두 메인 스레드다.
+ */
+class ScreenFrameStats {
+    var totalFrames: Long = 0L
+        private set
+
+    var jankFrames: Long = 0L
+        private set
+
+    var frozenFrames: Long = 0L
+        private set
+
+    val isEmpty: Boolean get() = totalFrames == 0L
+
+    fun record(
+        isJank: Boolean,
+        frameDurationNanos: Long,
+    ) {
+        totalFrames++
+        if (isJank) jankFrames++
+        if (frameDurationNanos >= FROZEN_FRAME_THRESHOLD_NANOS) frozenFrames++
+    }
+
+    fun reset() {
+        totalFrames = 0L
+        jankFrames = 0L
+        frozenFrames = 0L
+    }
+
+    companion object {
+        /** Firebase 자동 화면 Trace가 frozen frame으로 세는 기준과 같은 700ms. */
+        const val FROZEN_FRAME_THRESHOLD_NANOS: Long = 700_000_000L
+    }
+}

--- a/core/analytics/src/test/java/com/sseotdabwa/buyornot/core/analytics/performance/ScreenFrameStatsTest.kt
+++ b/core/analytics/src/test/java/com/sseotdabwa/buyornot/core/analytics/performance/ScreenFrameStatsTest.kt
@@ -1,6 +1,9 @@
 package com.sseotdabwa.buyornot.core.analytics.performance
 
 import org.junit.Test
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import kotlin.concurrent.thread
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
@@ -13,46 +16,90 @@ class ScreenFrameStatsTest {
     private val frozenFrame = ScreenFrameStats.FROZEN_FRAME_THRESHOLD_NANOS
 
     @Test
-    fun `프레임이 없으면 비어 있다`() {
-        assertTrue(stats.isEmpty)
+    fun `프레임이_없으면_비어_있다`() {
+        assertTrue(stats.snapshot().isEmpty)
     }
 
     @Test
-    fun `전체 프레임과 jank 프레임을 따로 센다`() {
+    fun `전체_프레임과_jank_프레임을_따로_센다`() {
         stats.record(isJank = false, frameDurationNanos = smoothFrame)
         stats.record(isJank = true, frameDurationNanos = jankFrame)
         stats.record(isJank = true, frameDurationNanos = jankFrame)
 
-        assertFalse(stats.isEmpty)
-        assertEquals(3L, stats.totalFrames)
-        assertEquals(2L, stats.jankFrames)
+        val snapshot = stats.snapshot()
+        assertFalse(snapshot.isEmpty)
+        assertEquals(3L, snapshot.totalFrames)
+        assertEquals(2L, snapshot.jankFrames)
     }
 
     @Test
-    fun `700ms 이상은 frozen 프레임으로도 센다`() {
+    fun `700ms_이상은_frozen_프레임으로도_센다`() {
         stats.record(isJank = true, frameDurationNanos = frozenFrame)
 
-        assertEquals(1L, stats.jankFrames)
-        assertEquals(1L, stats.frozenFrames)
+        val snapshot = stats.snapshot()
+        assertEquals(1L, snapshot.jankFrames)
+        assertEquals(1L, snapshot.frozenFrames)
     }
 
     @Test
-    fun `700ms 미만은 frozen이 아니다`() {
+    fun `700ms_미만은_frozen이_아니다`() {
         stats.record(isJank = true, frameDurationNanos = frozenFrame - 1)
 
-        assertEquals(1L, stats.jankFrames)
-        assertEquals(0L, stats.frozenFrames)
+        val snapshot = stats.snapshot()
+        assertEquals(1L, snapshot.jankFrames)
+        assertEquals(0L, snapshot.frozenFrames)
     }
 
     @Test
-    fun `reset은 이전 화면의 집계를 남기지 않는다`() {
+    fun `reset은_이전_화면의_집계를_남기지_않는다`() {
         stats.record(isJank = true, frameDurationNanos = frozenFrame)
 
         stats.reset()
 
-        assertTrue(stats.isEmpty)
-        assertEquals(0L, stats.totalFrames)
-        assertEquals(0L, stats.jankFrames)
-        assertEquals(0L, stats.frozenFrames)
+        val snapshot = stats.snapshot()
+        assertTrue(snapshot.isEmpty)
+        assertEquals(0L, snapshot.totalFrames)
+        assertEquals(0L, snapshot.jankFrames)
+        assertEquals(0L, snapshot.frozenFrames)
+    }
+
+    /**
+     * JankStats 콜백은 API 24+ 에서 메인 스레드가 아닌 프레임 메트릭스 스레드로 온다.
+     * 그 스레드의 [ScreenFrameStats.record] 와 메인 스레드의 읽기가 겹쳐도 카운트가 새지 않아야 한다.
+     */
+    @Test
+    fun `다른_스레드에서_동시에_기록해도_프레임_수가_새지_않는다`() {
+        val threadCount = 4
+        val framesPerThread = 10_000
+        val start = CountDownLatch(1)
+
+        val recorders =
+            List(threadCount) {
+                thread {
+                    start.await()
+                    repeat(framesPerThread) {
+                        stats.record(isJank = true, frameDurationNanos = frozenFrame)
+                    }
+                }
+            }
+        start.countDown()
+        recorders.forEach { it.join(TimeUnit.SECONDS.toMillis(10)) }
+
+        val snapshot = stats.snapshot()
+        val expected = (threadCount * framesPerThread).toLong()
+        assertEquals(expected, snapshot.totalFrames)
+        assertEquals(expected, snapshot.jankFrames)
+        assertEquals(expected, snapshot.frozenFrames)
+    }
+
+    @Test
+    fun `스냅샷은_이후의_기록에_영향받지_않는다`() {
+        stats.record(isJank = true, frameDurationNanos = jankFrame)
+        val snapshot = stats.snapshot()
+
+        stats.record(isJank = true, frameDurationNanos = jankFrame)
+
+        assertEquals(1L, snapshot.totalFrames)
+        assertEquals(2L, stats.snapshot().totalFrames)
     }
 }

--- a/core/analytics/src/test/java/com/sseotdabwa/buyornot/core/analytics/performance/ScreenFrameStatsTest.kt
+++ b/core/analytics/src/test/java/com/sseotdabwa/buyornot/core/analytics/performance/ScreenFrameStatsTest.kt
@@ -1,0 +1,58 @@
+package com.sseotdabwa.buyornot.core.analytics.performance
+
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ScreenFrameStatsTest {
+    private val stats = ScreenFrameStats()
+
+    private val smoothFrame = 8_000_000L
+    private val jankFrame = 20_000_000L
+    private val frozenFrame = ScreenFrameStats.FROZEN_FRAME_THRESHOLD_NANOS
+
+    @Test
+    fun `프레임이 없으면 비어 있다`() {
+        assertTrue(stats.isEmpty)
+    }
+
+    @Test
+    fun `전체 프레임과 jank 프레임을 따로 센다`() {
+        stats.record(isJank = false, frameDurationNanos = smoothFrame)
+        stats.record(isJank = true, frameDurationNanos = jankFrame)
+        stats.record(isJank = true, frameDurationNanos = jankFrame)
+
+        assertFalse(stats.isEmpty)
+        assertEquals(3L, stats.totalFrames)
+        assertEquals(2L, stats.jankFrames)
+    }
+
+    @Test
+    fun `700ms 이상은 frozen 프레임으로도 센다`() {
+        stats.record(isJank = true, frameDurationNanos = frozenFrame)
+
+        assertEquals(1L, stats.jankFrames)
+        assertEquals(1L, stats.frozenFrames)
+    }
+
+    @Test
+    fun `700ms 미만은 frozen이 아니다`() {
+        stats.record(isJank = true, frameDurationNanos = frozenFrame - 1)
+
+        assertEquals(1L, stats.jankFrames)
+        assertEquals(0L, stats.frozenFrames)
+    }
+
+    @Test
+    fun `reset은 이전 화면의 집계를 남기지 않는다`() {
+        stats.record(isJank = true, frameDurationNanos = frozenFrame)
+
+        stats.reset()
+
+        assertTrue(stats.isEmpty)
+        assertEquals(0L, stats.totalFrames)
+        assertEquals(0L, stats.jankFrames)
+        assertEquals(0L, stats.frozenFrames)
+    }
+}

--- a/core/ui/src/main/java/com/sseotdabwa/buyornot/core/ui/performance/ScreenRenderReporter.kt
+++ b/core/ui/src/main/java/com/sseotdabwa/buyornot/core/ui/performance/ScreenRenderReporter.kt
@@ -1,0 +1,54 @@
+package com.sseotdabwa.buyornot.core.ui.performance
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.runtime.withFrameNanos
+
+/**
+ * 화면 콘텐츠가 실제로 그려졌음을 계측 계층에 알리는 통로.
+ *
+ * 구현은 app 모듈이 주입한다. core/ui 가 계측 구현(Firebase 등)에 의존하지 않도록
+ * CompositionLocal 로 끊어 둔다.
+ */
+@Stable
+fun interface ScreenRenderReporter {
+    fun onScreenContentRendered()
+}
+
+/** 기본값은 no-op — 프리뷰와 테스트에서 별도 설정 없이 동작한다. */
+val LocalScreenRenderReporter =
+    staticCompositionLocalOf<ScreenRenderReporter> { ScreenRenderReporter { } }
+
+/**
+ * 콘텐츠가 준비된 뒤 **첫 프레임이 나간 시점**에 한 번 보고한다.
+ *
+ * 상태 반영 시점이 아니라 프레임 시점을 재는 것이 핵심이다. 상태만 보고 끝내면
+ * 컴포지션·레이아웃 비용(목록이라면 특히 크다)이 지표에서 빠진다.
+ *
+ * @param ready 스켈레톤/스피너가 아닌 **실제 콘텐츠**를 그릴 수 있는 상태.
+ *   로딩 인디케이터가 뜬 시점을 재지 않도록 호출부에서 로딩 상태를 제외해야 한다.
+ * @param onRendered 화면 고유의 추가 처리. 화면별 Trace 종료 등에 쓴다.
+ */
+@Composable
+fun ReportScreenRendered(
+    ready: Boolean,
+    onRendered: () -> Unit = {},
+) {
+    val reporter = LocalScreenRenderReporter.current
+    var reported by remember { mutableStateOf(false) }
+
+    LaunchedEffect(ready, reported) {
+        if (!ready || reported) return@LaunchedEffect
+        // 이 컴포지션 결과가 프레임으로 나간 뒤 재개된다. draw 완료보다 한 프레임 이내로 빠르다.
+        withFrameNanos { }
+        reported = true
+        reporter.onScreenContentRendered()
+        onRendered()
+    }
+}

--- a/feature/auth/src/main/java/com/sseotdabwa/buyornot/feature/auth/ui/LoginScreen.kt
+++ b/feature/auth/src/main/java/com/sseotdabwa/buyornot/feature/auth/ui/LoginScreen.kt
@@ -43,6 +43,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.sseotdabwa.buyornot.core.designsystem.icon.BuyOrNotIcons
 import com.sseotdabwa.buyornot.core.designsystem.icon.BuyOrNotImgs
 import com.sseotdabwa.buyornot.core.designsystem.theme.BuyOrNotTheme
+import com.sseotdabwa.buyornot.core.ui.performance.ReportScreenRendered
 import com.sseotdabwa.buyornot.core.ui.snackbar.LocalSnackbarState
 
 @Composable
@@ -71,6 +72,12 @@ fun AuthRoute(
             }
         }
     }
+
+    // 로그인 화면은 원격 데이터를 기다리지 않고 바로 그려지므로 항상 준비 상태다.
+    // isLoading은 소셜 로그인 진행 중 버튼을 잠그는 오버레이일 뿐 콘텐츠 준비 여부가 아니다.
+    // 로그인 시작 경로에서는 이 화면이 첫 의미 있는 화면이라, 여기서 보고하지 않으면
+    // 앱 시작 TTFD와 screen_render_auth Trace가 영영 닫히지 않는다.
+    ReportScreenRendered(ready = true)
 
     Box(
         modifier = Modifier.fillMaxSize(),

--- a/feature/auth/src/main/java/com/sseotdabwa/buyornot/feature/auth/ui/SplashScreen.kt
+++ b/feature/auth/src/main/java/com/sseotdabwa/buyornot/feature/auth/ui/SplashScreen.kt
@@ -30,6 +30,7 @@ import com.sseotdabwa.buyornot.core.designsystem.icon.BuyOrNotIcons
 import com.sseotdabwa.buyornot.core.designsystem.icon.BuyOrNotLotties
 import com.sseotdabwa.buyornot.core.designsystem.icon.asImageVector
 import com.sseotdabwa.buyornot.core.designsystem.theme.BuyOrNotTheme
+import com.sseotdabwa.buyornot.core.ui.performance.ReportScreenRendered
 
 /**
  * 스플래시 화면의 네비게이션 진입점
@@ -61,6 +62,10 @@ fun SplashRoute(
             }
         }
     }
+
+    // 스플래시는 데이터를 기다리지 않고 바로 그려지므로 항상 준비 상태다.
+    // 이 지표는 프로세스 시작부터 첫 화면이 실제로 나가기까지를 담는다.
+    ReportScreenRendered(ready = true)
 
     SplashScreen(
         updateDialogType = uiState.updateDialogType,

--- a/feature/home/src/main/java/com/sseotdabwa/buyornot/feature/home/ui/HomeScreen.kt
+++ b/feature/home/src/main/java/com/sseotdabwa/buyornot/feature/home/ui/HomeScreen.kt
@@ -86,6 +86,7 @@ import com.sseotdabwa.buyornot.core.designsystem.icon.BuyOrNotIcons
 import com.sseotdabwa.buyornot.core.designsystem.icon.BuyOrNotImgs
 import com.sseotdabwa.buyornot.core.designsystem.icon.asImageVector
 import com.sseotdabwa.buyornot.core.designsystem.theme.BuyOrNotTheme
+import com.sseotdabwa.buyornot.core.ui.performance.ReportScreenRendered
 import com.sseotdabwa.buyornot.domain.model.FeedCategory
 import com.sseotdabwa.buyornot.domain.model.UserType
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -142,6 +143,13 @@ fun HomeRoute(
             }
         }
     }
+
+    // isLoading 동안에는 CircularProgressIndicator가 그려지므로, 스피너가 아닌 실제 목록이
+    // 처음 프레임에 나간 시점을 렌더 완료로 본다.
+    ReportScreenRendered(
+        ready = !uiState.isLoading,
+        onRendered = viewModel::onFeedFirstContentRendered,
+    )
 
     HomeScreen(
         uiState = uiState,

--- a/feature/home/src/main/java/com/sseotdabwa/buyornot/feature/home/ui/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/sseotdabwa/buyornot/feature/home/ui/HomeViewModel.kt
@@ -57,6 +57,16 @@ class HomeViewModel @Inject constructor(
         loadInitialData()
     }
 
+    /**
+     * 피드 목록의 첫 프레임이 나간 시점에 UI가 호출한다.
+     *
+     * 데이터가 상태에 반영된 시점에 끊으면 LazyColumn 컴포지션·레이아웃 비용이 지표에서 빠져
+     * 체감 시간보다 짧게 나온다. 실패 경로는 이미 종료된 상태이므로 이 호출이 무시된다.
+     */
+    fun onFeedFirstContentRendered() {
+        feedFirstLoadTrace.stop()
+    }
+
     private fun observeUserPreferences() {
         viewModelScope.launch {
             var lastUserType: UserType? = null
@@ -586,7 +596,7 @@ class HomeViewModel @Inject constructor(
                 }
                 feedFirstLoadTrace.putAttribute("result", "success")
                 feedFirstLoadTrace.putMetric("feed_count", newFeeds.size.toLong())
-                feedFirstLoadTrace.stop()
+                // stop()은 목록이 실제로 그려진 뒤 onFeedFirstContentRendered()에서 호출한다.
             }.onFailure { e ->
                 Log.e("HomeViewModel", "Failed to load feeds", e)
                 updateState { it.copy(isLoading = false, hasError = true) }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -47,6 +47,11 @@ chucker = "4.3.1"
 # Analytics
 mixpanel = "7.5.3"
 
+# Performance
+# JankStats. 단일 Activity Compose 구조에서는 Firebase 자동 화면 Trace가 화면을 구분하지
+# 못하므로, 프레임에 route를 태깅해 화면별 jank를 직접 집계한다.
+metricsPerformance = "1.0.0"
+
 # org.json 실제 구현체. android.jar의 org.json은 유닛테스트에서 Stub!을 던지므로 테스트에서만 사용한다.
 json = "20250517"
 
@@ -144,6 +149,9 @@ lottie-compose = { group = "com.airbnb.android", name = "lottie-compose", versio
 # Analytics
 mixpanel-android = { group = "com.mixpanel.android", name = "mixpanel-android", version.ref = "mixpanel" }
 json = { group = "org.json", name = "json", version.ref = "json" }
+
+# Performance
+androidx-metrics-performance = { group = "androidx.metrics", name = "metrics-performance", version.ref = "metricsPerformance" }
 
 # Chucker
 chucker = { group = "com.github.chuckerteam.chucker", name = "library", version.ref = "chucker" }


### PR DESCRIPTION
## 🛠 Related issue
closed #136

어떤 변경사항이 있었나요?
- [x] 🐞 BugFix Something isn't working
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [x] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [x] ⚙️ Setting Development environment setup
- [x] ✅ Test Test related (Junit, etc.)

## ✅ CheckPoint
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 컨벤션에 맞게 작성했습니다. (필수)
- [x] merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕) (필수)
- [x] Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다. (필수)
- [x] BugFix의 경우, 버그의 원인을 파악하였습니다. (선택)

## ✏️ Work Description

#134에서 Firebase Performance를 붙였지만, **단일 Activity + Compose 구조라 자동 수집 지표가 세 방향으로 무력합니다.** 이 PR은 그 세 구멍을 메웁니다.

| 문제 | 원인 |
|---|---|
| 화면을 구분할 수 없다 | 자동 화면 Trace(`_st_<Activity>`)는 Activity/Fragment 단위. Activity가 `MainActivity` 하나뿐이라 `_st_MainActivity` 단 하나에 홈 피드·업로드·상세의 프레임이 전부 섞인다 |
| `_app_start`가 체감 시작 시간을 과소보고 | 첫 Activity의 `onResume`에서 종료되는데, Compose 앱의 `onResume`은 콘텐츠가 한 프레임도 그려지기 전이다 |
| `feed_first_load`가 렌더 비용을 놓침 | 데이터가 상태에 반영된 직후 `stop()`을 호출해 사실상 "데이터 도착 시간"을 재고 있었다 |

**1. 지표를 성질에 따라 두 종류로 분리 (설계의 핵심)**

성질이 다른 두 지표를 같은 도구로 잡으려 하면 설계가 꼬입니다.

| 지표 | 성질 | 도구 |
|---|---|---|
| TTID/TTFD (진입 → 콘텐츠 보임) | 단일 **구간 길이** | Firebase 커스텀 Trace |
| 화면별 jank (체류 중 프레임 품질) | 윈도우에 대한 **비율** | JankStats — 커스텀 Trace로는 프레임 데이터를 얻을 수 없음 |

발행되는 Trace 2종:

| Trace | 구간 | 측정항목 |
|---|---|---|
| `screen_render_<화면>` | 화면 진입 → 콘텐츠 첫 프레임 | — |
| `screen_frames_<화면>` | 화면 체류 구간 | `total_frames`, `jank_frames`, `frozen_frames` |

프레임 수는 기존 `PerfTrace.putMetric`에 그대로 실어서 새 추상화를 만들지 않았습니다.

**2. 첫 프레임 판정 — `ReportScreenRendered` (`core/ui`)**

`withFrameNanos`로 컴포지션 결과가 프레임으로 나간 뒤 보고합니다. 상태 반영 시점에 끊으면 컴포지션·레이아웃 비용(목록이면 특히 큼)이 지표에서 빠집니다.

`LocalScreenRenderReporter`(CompositionLocal)로 구현을 주입해 `core/ui`가 Firebase에 의존하지 않습니다. feature 모듈은 **1줄**로 참여하고, 기본값이 no-op이라 프리뷰·테스트에서 별도 설정이 필요 없습니다.

**3. JankStats 배선 (`MainActivity`)**

단일 Activity라 JankStats 인스턴스도 하나입니다. 화면 구분은 프레임에 붙는 `screen` 태그(`PerformanceMetricsState`)로 하고, 태그는 네비게이션 변경 시 갱신됩니다. 백그라운드에서는 추적을 끄고 구간을 끊어 체류 시간이 백그라운드 시간을 삼키지 않게 했습니다.

프레임 콜백은 매 프레임 돌기 때문에 `ScreenFrameStats.record()`는 할당 없이 카운터만 증가시킵니다.

**4. 앱 시작 TTFD — `ReportDrawnWhen`**

`_app_start`가 놓치는 Compose 첫 프레임 구간을 Play Vitals로 보냅니다. "스플래시가 아닌 첫 화면이 그려짐"을 조건으로 씁니다 — 스플래시가 그려진 것은 앱을 쓸 수 있는 상태가 아니기 때문입니다.

**5. `feed_first_load` 종료 시점 이동 (BugFix)**

성공 경로의 `stop()`을 첫 프레임으로 옮겼습니다. 속성·측정항목은 데이터 도착 시점에 그대로 실리고 종료만 늦춰집니다. `ready` 게이트는 `isLoading`을 제외합니다 — 로딩 중에는 `CircularProgressIndicator`가 그려지므로, 포함하면 스피너가 뜬 시각을 재게 됩니다.

**검증** — `:app:compileDebugKotlin` 통과, `testDebugUnitTest` **129개 통과**(신규 13개: `ScreenTraceNameTest` 8, `ScreenFrameStatsTest` 5), 전체 `ktlintCheck` 통과.

## 😅 Uncompleted Tasks
- [ ] **실기기 검증 미완** — logcat(`firebase_performance_logcat_enabled`)으로 Trace·프레임 수집 확인이 남았습니다. `ReportDrawnWhen` 조건과 route 태깅은 실제로 돌려봐야 확실합니다
- [ ] Firebase 콘솔에서 화면별 지표 분리 확인 — 콘솔 반영에 시간이 걸려 머지 후 확인 필요
- [ ] 나머지 화면(notification, mypage, upload) `ReportScreenRendered` 배선 — 현재 Home/Splash만
- [ ] jank 비율을 Mixpanel로 보내는 편이 나을지 검토 (아래 To Reviewers 참고)
- [ ] 랩 측정(Macrobenchmark `FrameTimingMetric` + composition tracing)으로 "왜 느린가" 확보 — 별도 과제

## 📢 To Reviewers

**route를 Trace 이름에 그대로 쓸 수 없었습니다** — 가장 봐주셨으면 하는 부분입니다. 타입 안전 네비게이션의 route는 fully-qualified 클래스명이고 일부는 인자를 갖습니다(`...FeedDetailRoute/{feedId}`). 그대로 쓰면 **feedId 값마다 고유 Trace 이름이 생겨** Firebase의 고유 이름 상한을 금방 넘깁니다. `screenTraceNameOf()`가 인자·패키지를 벗기고 snake_case 60자로 접어 **화면 종류 수만큼으로 bounded** 하게 유지합니다. 테스트로 이 계약을 고정했습니다.

**`reportFullyDrawn()`은 화면 전환에 재사용할 수 없습니다** — Activity당 첫 호출만 유효합니다. 그래서 `ReportDrawnWhen`은 앱 시작 TTFD에만 한 번 쓰고, 화면별 지표는 커스텀 Trace로 따로 만들었습니다. 처음에 이걸로 화면별 계측을 하려다 막힌 부분이라 남겨둡니다.

**이슈 계획에서 하나 뺐습니다 — `splash_to_navigation`은 확장하지 않았습니다.** 당초 이 Trace도 첫 프레임까지 늘리려 했는데, #135에서 이 지표를 **업데이트 팝업 대기(사용자 반응 시간)를 의도적으로 제외**하는 *로직 소요 시간*으로 설계하셨더군요. 렌더 시점 개념이 적용되지 않아 현행 유지했고, 스플래시 렌더는 `screen_render_splash`가 커버합니다. 이 판단이 맞는지 봐주세요.

**받아들인 트레이드오프 3개 — 이견 있으면 알려주세요**

1. **미완성 구간은 버립니다.** 콘텐츠 첫 프레임 전에 이탈하거나 백그라운드로 가면 render Trace를 `stop()` 하지 않습니다. Firebase는 stop되지 않은 Trace를 보고하지 않으므로 지표는 깨끗하지만, **이탈률은 이 지표로 알 수 없습니다.**
2. **미배선 화면은 조용히 비어 있습니다.** `ReportScreenRendered`를 넣지 않은 화면은 `screen_render_*`가 보고되지 않습니다. `screen_frames_*`는 이탈 시 flush되므로 모든 화면에서 정상 동작합니다. 배선은 각 Route 컴포저블에 1줄이면 됩니다.
3. **jank는 비율인데 Firebase는 sum/avg로 보여줍니다.** 콘솔에서 비율을 직접 계산해야 합니다. 이미 Mixpanel이 붙어 있으니 비율 계산·세그먼트는 그쪽이 편할 수도 있는데, 이슈 범위를 Firebase로 잡아서 일단 Firebase로 보냈습니다.

**프로덕션 RUM은 "어느 화면"까지만 답합니다** — "왜 느린가"는 Macrobenchmark + composition tracing이 필요합니다. 이 PR 범위 밖으로 뒀습니다.

## 📃 RCA 룰
- R: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
- C: 웬만하면 반영해 주세요. (Comment)
- A: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 화면별 렌더링 완료 시간과 체류 중 프레임 품질을 측정합니다.
  * 전체 프레임, 끊김 프레임, 장시간 지연 프레임을 구분해 성능 데이터를 수집합니다.
  * 실제 콘텐츠가 표시된 시점을 기준으로 초기 화면 로딩 성능을 기록합니다.
  * 화면 전환 및 백그라운드 진입 시 성능 측정을 안전하게 처리합니다.

* **테스트**
  * 화면 이름 변환과 프레임 통계 집계에 대한 검증을 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->