### PR TITLE
feat/#138: 화면 프레임 품질 지표에 jank/frozen 비율(‰) 추가

### DIFF
--- a/app/src/main/java/com/sseotdabwa/buyornot/performance/ScreenPerformanceTracker.kt
+++ b/app/src/main/java/com/sseotdabwa/buyornot/performance/ScreenPerformanceTracker.kt
@@ -110,9 +110,18 @@ class ScreenPerformanceTracker(
         // 프레임이 한 장도 없으면(즉시 스쳐 지나간 화면) 0으로 평균을 흐리지 않도록 버린다.
         if (stats.isEmpty) return
 
+        // 개수는 프레임 가중 집계용이다. 콘솔에서 sum(jank)/sum(total) 로 진짜 비율을 뽑을 수 있다.
         trace.putMetric(METRIC_TOTAL_FRAMES, stats.totalFrames)
         trace.putMetric(METRIC_JANK_FRAMES, stats.jankFrames)
         trace.putMetric(METRIC_FROZEN_FRAMES, stats.frozenFrames)
+
+        // 비율은 세션별 분포와 회귀 알림용이다. 개수와 달리 체류 시간에 오염되지 않아
+        // 화면 간 비교가 된다. 분모가 작으면 값이 튀므로 그때는 개수만 남긴다.
+        if (stats.isRateReliable) {
+            trace.putMetric(METRIC_JANK_RATE, stats.jankRatePermille)
+            trace.putMetric(METRIC_FROZEN_RATE, stats.frozenRatePermille)
+        }
+
         trace.stop()
     }
 
@@ -128,5 +137,9 @@ class ScreenPerformanceTracker(
         const val METRIC_TOTAL_FRAMES = "total_frames"
         const val METRIC_JANK_FRAMES = "jank_frames"
         const val METRIC_FROZEN_FRAMES = "frozen_frames"
+
+        // 정수 측정항목이라 비율은 ‰ 로 싣는다. 이름에 단위를 박아 콘솔에서 오독하지 않게 한다.
+        const val METRIC_JANK_RATE = "jank_rate_permille"
+        const val METRIC_FROZEN_RATE = "frozen_rate_permille"
     }
 }

--- a/app/src/test/java/com/sseotdabwa/buyornot/performance/ScreenPerformanceTrackerTest.kt
+++ b/app/src/test/java/com/sseotdabwa/buyornot/performance/ScreenPerformanceTrackerTest.kt
@@ -72,6 +72,34 @@ class ScreenPerformanceTrackerTest {
     }
 
     @Test
+    fun `프레임이_충분히_모이면_비율_측정항목도_함께_싣는다`() {
+        tracker.onScreenEntered(screen = HOME, sessionId = "entry-1")
+        repeat(90) { tracker.onFrame(isJank = false, frameDurationNanos = SMOOTH_FRAME) }
+        repeat(10) { tracker.onFrame(isJank = true, frameDurationNanos = JANK_FRAME) }
+        tracker.onPaused()
+
+        val metrics = framesTracesOf(HOME).single().metrics
+        assertEquals(100L, metrics["total_frames"])
+        assertEquals(10L, metrics["jank_frames"])
+        assertEquals(100L, metrics["jank_rate_permille"])
+    }
+
+    /** 2프레임 중 1 jank = 500‰ 같은 값이 trace 단위 비가중 평균을 지배하지 않도록 한다. */
+    @Test
+    fun `분모가_작은_구간은_개수만_싣고_비율은_생략한다`() {
+        tracker.onScreenEntered(screen = HOME, sessionId = "entry-1")
+        tracker.onFrame(isJank = false, frameDurationNanos = SMOOTH_FRAME)
+        tracker.onFrame(isJank = true, frameDurationNanos = JANK_FRAME)
+        tracker.onPaused()
+
+        val metrics = framesTracesOf(HOME).single().metrics
+        assertEquals(2L, metrics["total_frames"])
+        assertEquals(1L, metrics["jank_frames"])
+        assertFalse(metrics.containsKey("jank_rate_permille"))
+        assertFalse(metrics.containsKey("frozen_rate_permille"))
+    }
+
+    @Test
     fun `프레임이_한_장도_없는_구간은_보고하지_않는다`() {
         tracker.onScreenEntered(screen = HOME, sessionId = "entry-1")
         tracker.onScreenEntered(screen = DETAIL, sessionId = "entry-2")

--- a/core/analytics/src/main/java/com/sseotdabwa/buyornot/core/analytics/performance/ScreenFrameStats.kt
+++ b/core/analytics/src/main/java/com/sseotdabwa/buyornot/core/analytics/performance/ScreenFrameStats.kt
@@ -52,10 +52,31 @@ class ScreenFrameStats {
         val frozenFrames: Long,
     ) {
         val isEmpty: Boolean get() = totalFrames == 0L
+
+        /**
+         * 비율을 지표로 실을 만큼 프레임이 모였는지.
+         *
+         * 분모가 작으면 비율이 크게 튄다 — 2프레임 중 1 jank는 500‰ 이지만 화면 품질에 대해
+         * 아무것도 말해주지 않는다. Firebase는 측정항목을 trace 단위로 **비가중 평균** 하므로
+         * 이런 값 하나가 전체 평균을 지배한다. 그래서 짧은 구간은 카운트만 남기고 비율은 뺀다.
+         */
+        val isRateReliable: Boolean get() = totalFrames >= MIN_FRAMES_FOR_RATE
+
+        /** 전체 프레임 중 jank 프레임 비율 (‰). */
+        val jankRatePermille: Long get() = ratePermille(jankFrames)
+
+        /** 전체 프레임 중 frozen 프레임 비율 (‰). */
+        val frozenRatePermille: Long get() = ratePermille(frozenFrames)
+
+        /** 정수 지표라 ‰ 로 싣는다. 내림이 아니라 반올림해 작은 비율이 0으로 눌리지 않게 한다. */
+        private fun ratePermille(count: Long): Long = if (totalFrames == 0L) 0L else (count * 1_000L + totalFrames / 2) / totalFrames
     }
 
     companion object {
         /** Firebase 자동 화면 Trace가 frozen frame으로 세는 기준과 같은 700ms. */
         const val FROZEN_FRAME_THRESHOLD_NANOS: Long = 700_000_000L
+
+        /** 비율을 신뢰할 수 있는 최소 프레임 수. 60Hz에서 약 0.5초. */
+        const val MIN_FRAMES_FOR_RATE: Long = 30L
     }
 }

--- a/core/analytics/src/test/java/com/sseotdabwa/buyornot/core/analytics/performance/ScreenFrameStatsTest.kt
+++ b/core/analytics/src/test/java/com/sseotdabwa/buyornot/core/analytics/performance/ScreenFrameStatsTest.kt
@@ -92,6 +92,73 @@ class ScreenFrameStatsTest {
         assertEquals(expected, snapshot.frozenFrames)
     }
 
+    private fun recordFrames(
+        total: Int,
+        jank: Int = 0,
+        frozen: Int = 0,
+    ) {
+        repeat(frozen) { stats.record(isJank = true, frameDurationNanos = frozenFrame) }
+        repeat(jank - frozen) { stats.record(isJank = true, frameDurationNanos = jankFrame) }
+        repeat(total - jank) { stats.record(isJank = false, frameDurationNanos = smoothFrame) }
+    }
+
+    @Test
+    fun `비율은_전체_프레임_대비_천분율로_계산한다`() {
+        recordFrames(total = 1000, jank = 30, frozen = 6)
+
+        val snapshot = stats.snapshot()
+        assertEquals(30L, snapshot.jankRatePermille)
+        assertEquals(6L, snapshot.frozenRatePermille)
+    }
+
+    /** 내림이면 작은 비율이 전부 0으로 눌려 회귀를 못 본다. */
+    @Test
+    fun `비율은_내림이_아니라_반올림한다`() {
+        // 3/400 = 7.5‰ → 8‰
+        recordFrames(total = 400, jank = 3)
+
+        assertEquals(8L, stats.snapshot().jankRatePermille)
+    }
+
+    @Test
+    fun `모든_프레임이_jank면_1000천분율이다`() {
+        recordFrames(total = 50, jank = 50)
+
+        assertEquals(1000L, stats.snapshot().jankRatePermille)
+    }
+
+    @Test
+    fun `프레임이_없으면_비율은_0이고_나눗셈이_터지지_않는다`() {
+        val snapshot = stats.snapshot()
+
+        assertEquals(0L, snapshot.jankRatePermille)
+        assertEquals(0L, snapshot.frozenRatePermille)
+    }
+
+    @Test
+    fun `분모가_최소_프레임_수에_미치지_못하면_비율을_신뢰하지_않는다`() {
+        recordFrames(total = (ScreenFrameStats.MIN_FRAMES_FOR_RATE - 1).toInt(), jank = 1)
+
+        assertFalse(stats.snapshot().isRateReliable)
+    }
+
+    @Test
+    fun `분모가_최소_프레임_수에_도달하면_비율을_신뢰한다`() {
+        recordFrames(total = ScreenFrameStats.MIN_FRAMES_FOR_RATE.toInt(), jank = 1)
+
+        assertTrue(stats.snapshot().isRateReliable)
+    }
+
+    @Test
+    fun `reset하면_비율_신뢰_여부도_되돌아간다`() {
+        recordFrames(total = 100, jank = 10)
+        assertTrue(stats.snapshot().isRateReliable)
+
+        stats.reset()
+
+        assertFalse(stats.snapshot().isRateReliable)
+    }
+
     @Test
     fun `스냅샷은_이후의_기록에_영향받지_않는다`() {
         stats.record(isJank = true, frameDurationNanos = jankFrame)


### PR DESCRIPTION
## 🛠 Related issue
closed #138

어떤 변경사항이 있었나요?
- [ ] 🐞 BugFix Something isn't working
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [x] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (Junit, etc.)

## ✅ CheckPoint
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 컨벤션에 맞게 작성했습니다. (필수)
- [x] merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕) (필수)
- [ ] Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다. (필수)
- [ ] BugFix의 경우, 버그의 원인을 파악하였습니다. (선택)

## ✏️ Work Description

- `screen_frames_<화면>` Trace에 `jank_rate_permille` / `frozen_rate_permille` 두 측정항목을 추가했습니다. 프레임 **개수**만으로는 화면 간 비교가 성립하지 않기 때문입니다 — `jank_frames = 30` 은 300프레임 중 30이면 심각하고(100‰) 30,000프레임 중 30이면 정상(1‰)인데 지표만 봐서는 구분할 수 없고, 체류 시간이 긴 화면일수록 값이 무조건 커집니다.
- `ScreenFrameStats.Snapshot` 에 `jankRatePermille` / `frozenRatePermille` / `isRateReliable` 계산 속성을 추가하고, `ScreenPerformanceTracker.stopFramesTrace()` 가 조건부로 싣도록 연결했습니다.
- 정수 측정항목이라 비율은 **‰** 로 싣고 지표 이름에 단위를 박았습니다. 콘솔에서 `10` 만 보면 단위를 알 수 없기 때문입니다.
- 내림이 아니라 **반올림** 합니다(`(count*1000 + total/2)/total`). 내림이면 frozen처럼 작은 비율이 전부 0으로 눌려 회귀를 관측할 수 없습니다.
- **30프레임**(60Hz에서 약 0.5초) 미만인 구간은 개수만 싣고 비율은 생략합니다. 구간 자체는 버리지 않아 체류 시간·프레임 수 정보는 유지됩니다.
- 단위 테스트 24건 (`ScreenFrameStatsTest` 14, `ScreenPerformanceTrackerTest` 10). 반올림, 29/30 경계, 0 분모, 1000‰ 상한, 비율 생략 동작을 덮었습니다.

## 😅 Uncompleted Tasks
- [ ] Firebase 콘솔에서 `jank_rate_permille` / `frozen_rate_permille` 실제 수집 확인 (배포 후에만 가능)

## 📢 To Reviewers

**개수를 비율로 "교체" 하지 않은 이유** 를 봐주시면 좋겠습니다. 처음엔 비율로 갈아끼우려 했는데, Firebase 커스텀 측정항목은 **trace 단위로 비가중 평균** 을 내기 때문에 비율만 남기면 짧은 체류가 전체 숫자를 지배합니다:

| 체류 | 프레임 | jank | 비율 |
|---|---|---|---|
| 스쳐 지나간 화면 | 3 | 2 | 667‰ |
| 실제로 오래 쓴 화면 | 3,000 | 30 | 10‰ |

Firebase가 보여주는 평균은 `(667+10)/2 = 338‰` 이지만 실제 값은 `32/3003 = 10.7‰` 입니다.

개수를 남겨두면 콘솔에서 `sum(jank_frames)/sum(total_frames)` 로 프레임 가중된 진짜 비율을 뽑을 수 있는데, 비율 지표는 이게 안 됩니다(콘솔에서 지표 간 사칙연산 불가). 그래서 둘은 서로를 대체하지 못하고 보완한다고 판단했습니다. 측정항목 상한이 32개라 자리도 넉넉합니다(현재 5개 사용).

**역할 분담**
- 개수 → 프레임 가중 집계용 (정확한 분모/분자 보존)
- 비율 → 세션별 분포와 회귀 알림용 (체류 시간에 오염되지 않음)

`MIN_FRAMES_FOR_RATE = 30` 값과 ‰ 단위 선택(vs ‱)에 다른 의견 있으시면 말씀해 주세요. ‰ 로 정한 근거는 개수가 남아 있어 정밀 분석은 `sum/sum` 으로 가능하므로 0.1% 해상도로 충분하고, ‱ 보다 읽기 쉽다는 점입니다.

## 📃 RCA 룰
- R: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
- C: 웬만하면 반영해 주세요. (Comment)
- A: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 화면 성능 측정에 세션별 끊김(jank) 및 멈춤(frozen) 프레임 비율 지표를 추가했습니다.
  * 충분한 프레임이 수집된 경우에만 신뢰 가능한 비율을 천분율로 기록합니다.
  * 프레임 수가 적은 구간에서는 기존 개수 지표만 기록해 측정 신뢰도를 높였습니다.

* **테스트**
  * 비율 계산, 반올림, 빈 데이터 및 최소 프레임 기준을 검증하는 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->