### PR TITLE
Release 0.3.4 to develop

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -32,8 +32,8 @@ android {
 
     defaultConfig {
         applicationId = "com.sseotdabwa.buyornot"
-        versionCode = 10
-        versionName = "0.3.3"
+        versionCode = 11
+        versionName = "0.3.4"
 
         buildConfigField("String", "KAKAO_NATIVE_APP_KEY", "\"${localProperties.getProperty("kakao.nativeAppKey", "")}\"")
         manifestPlaceholders["NATIVE_APP_KEY"] = localProperties.getProperty("kakao.nativeAppKey", "")

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,6 +17,20 @@
         android:supportsRtl="true"
         android:windowSoftInputMode="adjustResize"
         android:theme="@style/Theme.BuyOrNot">
+
+        <!--
+            targetSdk 36부터 Android는 sw600dp 이상 화면(태블릿·폴더블 내부 화면·데스크톱 창)에서
+            screenOrientation·resizeableActivity·aspect-ratio 제한을 무시한다. 이 속성이 그 무시를
+            거부해 아래 MainActivity의 세로 고정이 대화면에서도 유지되게 한다.
+
+            가로 레이아웃이 준비되지 않아 둔 임시 조치다(#145). 이 opt-out은 targetSdk 37부터
+            프레임워크에서 제거되므로, 37로 올리기 전에 #145가 끝나야 한다.
+            https://developer.android.com/about/versions/17/changes/ff-restrictions-ignored
+        -->
+        <property
+            android:name="android.window.PROPERTY_COMPAT_ALLOW_RESTRICTED_RESIZABILITY"
+            android:value="true" />
+
         <meta-data
             android:name="com.google.firebase.messaging.default_notification_channel_id"
             android:value="buyornot_default_channel" />
@@ -35,6 +49,7 @@
             android:exported="true"
             android:label="@string/app_name"
             android:launchMode="singleTop"
+            android:screenOrientation="portrait"
             android:theme="@style/Theme.BuyOrNot">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />


### PR DESCRIPTION
## 🛠 Related issue
closed #140
closed #143

어떤 변경사항이 있었나요?
- [ ] 🐞 BugFix Something isn't working
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [ ] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [x] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (Junit, etc.)

## ✅ CheckPoint
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 컨벤션에 맞게 작성했습니다. (필수)
- [x] merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕) (필수)
- [ ] Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다. (필수)
- [ ] BugFix의 경우, 버그의 원인을 파악하였습니다. (선택)

## ✏️ Work Description

**1. 버전 업 (#140)** — `versionCode` 10 → 11, `versionName` "0.3.3" → "0.3.4".

**2. 세로 회전 고정 (#143)** — ⚠️ **동작 변경입니다.**

- `MainActivity` 에 `android:screenOrientation="portrait"` 추가
- `<application>` 에 `PROPERTY_COMPAT_ALLOW_RESTRICTED_RESIZABILITY=true` 추가

병합 매니페스트로 세 변경 모두 반영 확인했습니다:
```
version: 11 0.3.4
<application> properties:
  android.window.PROPERTY_COMPAT_ALLOW_RESTRICTED_RESIZABILITY = true
activity orientations:
  MainActivity  screenOrientation=portrait  <-- LOCKED
```

## 😅 Uncompleted Tasks
- [ ] 폰 에뮬레이터에서 회전해도 세로 유지 확인
- [ ] 태블릿(sw600dp+) 에뮬레이터에서 세로 유지 확인 — opt-out 이 실제로 먹는지 확인하는 게 핵심입니다

## 📢 To Reviewers

### 왜 세로 고정인가

지금까지 이 앱은 orientation 을 선언하지 않아 **자유 회전 상태**였습니다. 그런데 UI 가 세로 전제로 만들어져 있어 가로에서 실제로 기능이 막힙니다. 조사 중 발견한 대표 2건:

- `WithdrawalScreen.kt:121` — 높이 상한·`aspectRatio` 가드가 없는 `Image(fillMaxWidth)` 가 남은 높이를 전부 삼켜, 뒤에 측정되는 탈퇴하기 버튼이 0 을 받습니다 → **회원탈퇴 불가**
- `LoginScreen.kt:112` — 스크롤 컨테이너 없이 고정 높이 합계가 ≈446dp 인데 가로 뷰포트는 시스템 바 제외 ≈340dp → **약관·개인정보처리방침 링크가 화면 밖으로 나가 탭 불가**

레이아웃을 제대로 고치는 건 시간이 걸려서, 일단 세로로 고정해 막고 후속 이슈로 분리했습니다.

### 왜 opt-out 속성이 함께 필요한가

targetSdk 는 이미 36 입니다(`AndroidApplicationConventionPlugin.kt:17`). Android 16 은 targetSdk 36 앱의 orientation/aspect-ratio/resizability 제한을 **sw600dp 이상 화면에서 무시**합니다. 즉 `screenOrientation="portrait"` 만 넣으면 폰에서는 고정되지만 **태블릿·폴더블 내부 화면에서는 여전히 회전**합니다. opt-out 을 함께 넣어야 선언한 제한이 대화면에서도 존중됩니다.

> ⏳ **시한이 있습니다.** 이 opt-out 은 targetSdk 37 부터 프레임워크에서 제거됩니다. 37 로 올리기 전에 #145 가 끝나야 합니다.

### 세로 고정이 해결하지 못하는 것 — #144

세로 고정은 **회전으로 인한** 설정 변경만 막습니다. Activity 재생성은 **백그라운드 프로세스 사망**(실사용에서 반드시 발생), 멀티윈도우 리사이즈, 시스템 글꼴·표시 크기 변경, 다크모드·로케일 변경으로도 일어납니다. 그래서 아래는 이 PR 로 **안 고쳐집니다**:

- `UploadScreen.kt:119` — `photoUri` 가 plain `remember` 라, 카메라 촬영 중 프로세스가 죽으면 찍은 사진이 조용히 사라집니다 (크롭 화면도 안 뜨고 에러도 없음)
- `MainActivity.kt:43` — `pendingFeedDeepLink` 가 평범한 필드라, 인증 게이트 통과 전 재생성되면 딥링크가 영구 소실됩니다

전 앱에 `rememberSaveable` 이 1개, `onSaveInstanceState` 가 0개입니다. #144 에 전체 목록을 정리했습니다.

### 후속 이슈

| 이슈 | 내용 |
|---|---|
| #144 | 설정 변경 시 상태 유실 — 세로 고정과 무관하게 지금도 터짐, 우선순위 높음 |
| #145 | 가로/대화면 레이아웃 대응 — 이 PR 로 가려진 문제, targetSdk 37 전까지 |

### 알아두실 점

Kakao/Google 인증 브리지 액티비티 8개는 orientation 선언이 없어 자유 회전입니다. 우리 UI 가 아닌 전환용 화면이라 이번 범위에서 두었습니다.

## 📃 RCA 룰
- R: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
- C: 웬만하면 반영해 주세요. (Comment)
- A: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
